### PR TITLE
Document MongoDB types

### DIFF
--- a/usage/sync-rules/types.mdx
+++ b/usage/sync-rules/types.mdx
@@ -26,8 +26,8 @@ Postgres values are mapped according to this table:
 | float4, float8     | real                           |                                                                                                                                                                                                                             |
 | enum               | text                           |                                                                                                                                                                                                                             |
 | uuid               | text                           |                                                                                                                                                                                                                             |
-| timestamptz        | text                           | Format: YYYY-MM-DD hh:mm:ss.sssZThis is compatible with ISO8601 and SQLite's functions. Precision matches the precision used in Postgres.\-infinity becomes 0000-01-01 00:00:00Z and infinity becomes 9999-12-31 23:59:59Z. |
-| timestamp          | text                           | Format: YYYY-MM-DD hh:mm:ss.sssIn most cases, timestamptz should be used instead.\-infinity becomes 0000-01-01 00:00:00 and infinity becomes 9999-12-31 23:59:59.                                                           |
+| timestamptz        | text                           | Format: `YYYY-MM-DD hh:mm:ss.sssZ`. This is compatible with ISO8601 and SQLite's functions. Precision matches the precision used in Postgres. `-infinity` becomes `0000-01-01 00:00:00Z` and `infinity` becomes `9999-12-31 23:59:59Z`. |
+| timestamp          | text                           | Format: `YYYY-MM-DD hh:mm:ss.sss`. In most cases, timestamptz should be used instead. `-infinity` becomes `0000-01-01 00:00:00` and `infinity` becomes `9999-12-31 23:59:59`.                                                           |
 | date, time         | text                           |                                                                                                                                                                                                                             |
 | json, jsonb        | text                           | There is no dedicated JSON type — JSON functions operate directly on text values.                                                                                                                                           |
 | interval           | text                           |                                                                                                                                                                                                                             |
@@ -46,11 +46,33 @@ There is no dedicated boolean data type. Boolean values are represented as `1` (
   This section is a work in progress. More details for MongoDB connections are coming soon. In the meantime, check our [MongoDB guide](/migration-guides/mongodb-atlas) to try out our MongoDB alpha support, and ask on our [Discord server](https://discord.gg/powersync) if you have any questions.
 </Info>
 
+| BSON Type          | PowerSync / SQLite Column Type | Notes |
+| ------------------ | ------------------------------ | ----- |
+| String             | text                           |  |
+| Int, Long          | integer                        |  |
+| Double             | real                           |  |
+| Decimal128         | text                           |  |
+| Object             | text                           | Converted to a JSON string |
+| Array              | text                           | Converted to a JSON string |
+| ObjectId           | text                           | Lower-case hex string |
+| UUID               | text                           | Lower-case hex string |
+| Boolean            | integer                        | 1 for true, 0 for false |
+| Date               | text                           | Format: `YYYY-MM-DD hh:mm:ss.sss` |
+| Null               | null                           |  |
+| Binary             | blob                           | Cannot sync directly to client — convert to hex or base64 first. See [Operators & Functions](/usage/sync-rules/operators-and-functions). |
+| Regular Expression | text                           | JSON text in the format `{"pattern":"...","options":"..."}` |
+| Timestamp          | integer                        | Converted to a 64-bit integer |
+| Undefined          | null                           |  |
+| DBPointer          | text                           | JSON text in the format `{"collection":"...","oid":"...","db":"...","fields":...}` | 
+| JavaScript         | text                           | JSON text in the format `{"code": "...", "scope": ...}` |
+| Symbol             | text                           |  |
+| MinKey, MaxKey     | null                           |  |
+
 * Data is converted to a flat list of columns, one column per top-level field in the MongoDB document.
 * Special BSON types are converted to plain SQLite alternatives.
 * For example, `ObjectId`, `Date`, `UUID` are all converted to a plain `TEXT` column.
 * Nested objects and arrays are converted to JSON arrays, and JSON operators can be used to query them (in the Sync Rules and/or on the client-side).
-
+* Binary data nested in objects or arrays is not supported.
 
 ## <Icon icon="dolphin" iconType="solid" size="24"/> MySQL (Alpha) Type Mapping
 


### PR DESCRIPTION
Note: Not all of these are supported in the current cloud version, but a fix supporting this table as-is will be released next week.