### PR TITLE
chore: Added TS example for drizzle watched queries

### DIFF
--- a/client-sdk-references/javascript-web/javascript-orm/drizzle.mdx
+++ b/client-sdk-references/javascript-web/javascript-orm/drizzle.mdx
@@ -175,9 +175,21 @@ Below are examples comparing Drizzle and PowerSync syntax for common database op
   powerSyncDb.watch(compiledQuery.sql, compiledQuery.parameters, {
     onResult(results) {
       console.log(results.rows?._array);
+    },
+  });
 
-      // With Typescript typing
-      // console.log((results.rows?._array as (typeof users.$inferSelect)[]));
+  // [{ id: '1', name: 'John' }]
+  ```
+
+  ```ts Drizzle (TS)
+  import { toCompilableQuery } from "@powersync/drizzle-driver";
+
+  // `compile()` is automatically called internally in the hooks, but not for `watch()`
+  const compiledQuery = toCompilableQuery(db.select().from(users)).compile();
+
+  powerSyncDb.watch(compiledQuery.sql, compiledQuery.parameters as [], {
+    onResult(results) {
+      console.log((results.rows?._array as (typeof users.$inferSelect)[]));
     },
   });
 


### PR DESCRIPTION
Added a TS table for the Drizzle watch query example, this allows you to compared Drizzle, Drizzle-ts, and PowerSync snippets.
![Screenshot 2024-11-14 at 10 56 38](https://github.com/user-attachments/assets/54682bb3-0dc2-4c5b-b743-2fa27c0f590a)
![Screenshot 2024-11-14 at 10 56 46](https://github.com/user-attachments/assets/fe0f4e75-fef0-4caf-87c4-d4c7bc9af770)

