### PR TITLE
Updated Drizzle docs to use Drizzle watch() function.

### DIFF
--- a/client-sdk-references/javascript-web/javascript-orm/drizzle.mdx
+++ b/client-sdk-references/javascript-web/javascript-orm/drizzle.mdx
@@ -165,31 +165,16 @@ Below are examples comparing Drizzle and PowerSync syntax for common database op
 
 ### Watched Queries
 
+For watched queries with Drizzle it's recommended to use the `watch()` function from the Drizzle integration which takes in a Drizzle query. 
+
 <CodeGroup>
   ```js Drizzle
-  import { toCompilableQuery } from "@powersync/drizzle-driver";
 
-  // `compile()` is automatically called internally in the hooks, but not for `watch()`
-  const compiledQuery = toCompilableQuery(db.select().from(users)).compile();
+  const query = db.select().from(users);
 
-  powerSyncDb.watch(compiledQuery.sql, compiledQuery.parameters, {
+  db.watch(query, {
     onResult(results) {
-      console.log(results.rows?._array);
-    },
-  });
-
-  // [{ id: '1', name: 'John' }]
-  ```
-
-  ```ts Drizzle (TS)
-  import { toCompilableQuery } from "@powersync/drizzle-driver";
-
-  // `compile()` is automatically called internally in the hooks, but not for `watch()`
-  const compiledQuery = toCompilableQuery(db.select().from(users)).compile();
-
-  powerSyncDb.watch(compiledQuery.sql, compiledQuery.parameters as [], {
-    onResult(results) {
-      console.log((results.rows?._array as (typeof users.$inferSelect)[]));
+      console.log(results);
     },
   });
 


### PR DESCRIPTION
Updated docs to match API changes made [here](https://github.com/powersync-ja/powersync-js/pull/414).
This is a less issue prone and more convenient way to use watched queries with Drizzle.

![image](https://github.com/user-attachments/assets/64f151d0-ce62-4236-9b34-e8b49375fd6e)
