### PR TITLE
Update MongoDB docs on permissions and postImages

### DIFF
--- a/installation/database-setup.mdx
+++ b/installation/database-setup.mdx
@@ -399,7 +399,7 @@ You can view which collections have the option enabled using:
 db.getCollectionInfos().filter(c => c.options?.changeStreamPreAndPostImages?.enabled)
 ```
 
-A PowerSync instance can alternative be configured to replicate using `fullDocument: 'updateLookup'`.
+A PowerSync instance can alternatively be configured to replicate using `fullDocument: 'updateLookup'`.
 This was the default for older instances. However, this may lead to consistency issues,
 so we strongly recommend enabling postImages support instead.
 


### PR DESCRIPTION
The postImages configuration option must still be deployed for the cloud version, but I'm documenting the requirements in the meantime.

The page is getting quite meaty - perhaps we should look into splitting up the page for Postgres/MongoDB/MySQL?