### PR TITLE
Update MongoDB Alpha notes

### DIFF
--- a/migration-guides/mongodb-atlas.mdx
+++ b/migration-guides/mongodb-atlas.mdx
@@ -106,15 +106,15 @@ Refer to the instructions above on how to use the current alpha support for Mong
 
 **Known Issues (Alpha)**
 
-- [ ] MongoDB -> PowerSync Service replication is not optimized for performance yet. We are targeting 2,000+ operations per second for the Beta.
-- [ ] Unhelpful "Something went wrong" error in the Dashboard when PowerSync IPs have not been allowed for Atlas users (Network Access -> IP Access List)
-- [ ] Unhelpful "Something went wrong" error in the Dashboard when `mongodb://` is used for the URI scheme; `mongodb+srv://` must be used
-- [ ] Consistency guarantees are currently _eventually consistent_ — that is, operations can arrive out of order on the client. We are targeting to provide _causal+ consistency_ using  `changeStreamPreAndPostImages`
+- [x] **FIXED**: MongoDB -> PowerSync Service replication is not optimized for performance yet. We are targeting 2,000+ operations per second for the Beta.
+- [x] **FIXED**: Unhelpful "Something went wrong" error in the Dashboard when PowerSync IPs have not been allowed for Atlas users (Network Access -> IP Access List)
+- [x] **FIXED**: Unhelpful "Something went wrong" error in the Dashboard when `mongodb://` is used for the URI scheme; `mongodb+srv://` must be used
+- [x] **FIXED**: Consistency guarantees are currently _eventually consistent_ — that is, operations can arrive out of order on the client. We are targeting to provide _causal+ consistency_ using  `changeStreamPreAndPostImages`. **Update:** Instances can now be configured to use Post Images to resolve consistency issues.
 
 #### Beta (In Progress - ETA 2024Q4)
 - [x] Availability in PowerSync Cloud
-- [ ] Fully functional diagnostics API
-- [ ] Validate that TLS connections Just Work ™️ without any additional configuration
-- [ ] Address all known issues in _Known Issues_
+- [x] Fully functional diagnostics API
+- [x] Validate that TLS connections Just Work ™️ without any additional configuration
+- [x] Address all known issues in _Known Issues_
 
 #### V1 (Not Started) — Estimated start 2025Q1


### PR DESCRIPTION
All the todos for Beta are now completed, even though I'm not sure when we're actually calling it Beta.

Side note: The migration guide feels like a weird place to track the MongoDB status. Should probably also change that when we split out database connection pages.