### PR TITLE
fix: upload data link issue

### DIFF
--- a/client-sdk-references/javascript-web.mdx
+++ b/client-sdk-references/javascript-web.mdx
@@ -165,8 +165,8 @@ It is used to:
 
 Accordingly, the connector must implement two methods:
 
-1. [PowerSyncBackendConnector.fetchCredentials](https://powersync-ja.github.io/powersync-js/web-sdk/interfaces/PowerSyncBackendConnector#fetchcredentials) - This is called every couple of minutes and is used to obtain credentials for your app backend API. -> See [Authentication Setup](/installation/authentication-setup) for instructions on how the credentials should be generated.
-2. [PowerSyncBackendConnector.uploadData](https://powersync-ja.github.io/powersync-js/web-sdk/interfaces/PowerSyncBackendConnector#uploaddata) - Use this to upload client-side changes to your app backend.
+1. [PowerSyncBackendConnector.fetchCredentials](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/client/connection/PowerSyncBackendConnector.ts#L16) - This is called every couple of minutes and is used to obtain credentials for your app backend API. -> See [Authentication Setup](/installation/authentication-setup) for instructions on how the credentials should be generated.
+2. [PowerSyncBackendConnector.uploadData](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/client/connection/PowerSyncBackendConnector.ts#L24) - Use this to upload client-side changes to your app backend.
    -> See [Writing Client Changes](/installation/app-backend-setup/writing-client-changes) for considerations on the app backend implementation.
 
 **Example**:

--- a/client-sdk-references/javascript-web/usage-examples.mdx
+++ b/client-sdk-references/javascript-web/usage-examples.mdx
@@ -19,7 +19,7 @@ The shared database worker will ensure writes to the database will instantly be 
 
 The shared sync worker connects directly to the PowerSync backend instance and applies changes to the database. Note that the shared sync worker will call the `fetchCredentials` and `uploadData` method of the latest opened available tab. Closing a tab will shift the latest tab to the previously opened one.
 
-Currently, using the SDK in multiple tabs without enabling the [enableMultiTabs](https://powersync-ja.github.io/powersync-js/web-sdk/interfaces/WebPowerSyncFlags#enablemultitabs) flag will spawn a standard web worker per tab for DB operations. These workers are safe to operate on the DB concurrently, however changes from one tab may not update watches on other tabs. Only one tab can sync from the PowerSync instance at a time. The sync status will not be shared between tabs, only the oldest tab will connect and display the latest sync status.
+Currently, using the SDK in multiple tabs without enabling the [enableMultiTabs](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/web/src/db/adapters/web-sql-flags.ts#L23) flag will spawn a standard web worker per tab for DB operations. These workers are safe to operate on the DB concurrently, however changes from one tab may not update watches on other tabs. Only one tab can sync from the PowerSync instance at a time. The sync status will not be shared between tabs, only the oldest tab will connect and display the latest sync status.
 
 Support is enabled by default if available. This can be disabled as below:
 
@@ -158,7 +158,7 @@ return (
 
 ## Send changes in local data to your backend service
 
-Override [uploadData](https://powersync-ja.github.io/powersync-js/web-sdk/interfaces/PowerSyncBackendConnector#uploaddata) to send local updates to your backend service.
+Override [uploadData](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/client/connection/PowerSyncBackendConnector.ts#L24) to send local updates to your backend service.
 
 
 ```js

--- a/client-sdk-references/react-native-and-expo.mdx
+++ b/client-sdk-references/react-native-and-expo.mdx
@@ -171,8 +171,8 @@ It is used to:
 
 Accordingly, the connector must implement two methods:
 
-1. [PowerSyncBackendConnector.fetchCredentials](https://powersync-ja.github.io/powersync-js/react-native-sdk/interfaces/PowerSyncBackendConnector#fetchcredentials) \- This is called every couple of minutes and is used to obtain credentials for your app backend API. -> See [Authentication Setup](/installation/authentication-setup) for instructions on how the credentials should be generated.
-2. [PowerSyncBackendConnector.uploadData](https://powersync-ja.github.io/powersync-js/react-native-sdk/interfaces/PowerSyncBackendConnector#uploaddata) \- Use this to upload client-side changes to your app backend.
+1. [PowerSyncBackendConnector.fetchCredentials](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/client/connection/PowerSyncBackendConnector.ts#L16) \- This is called every couple of minutes and is used to obtain credentials for your app backend API. -> See [Authentication Setup](/installation/authentication-setup) for instructions on how the credentials should be generated.
+2. [PowerSyncBackendConnector.uploadData](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/client/connection/PowerSyncBackendConnector.ts#L24) \- Use this to upload client-side changes to your app backend.
 \-> See [Writing Client Changes](/installation/app-backend-setup/writing-client-changes) for considerations on the app backend implementation.
 
 **Example**:

--- a/client-sdk-references/react-native-and-expo/usage-examples.mdx
+++ b/client-sdk-references/react-native-and-expo/usage-examples.mdx
@@ -7,7 +7,7 @@ description: "Code snippets and guidelines for common scenarios"
 
 Read and write transactions present a context where multiple changes can be made then finally committed to the DB or rolled back. This ensures that either all the changes get persisted, or no change is made to the DB (in the case of a rollback or exception).
 
-[PowerSyncDatabase.writeTransaction(callback)](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#writetransaction) automatically commits changes after the transaction callback is completed if [tx.rollback()](https://powersync-ja.github.io/powersync-js/react-native-sdk/interfaces/Transaction#rollback) has not explicitly been called. If an exception is thrown in the callback then changes are automatically rolled back.
+[PowerSyncDatabase.writeTransaction(callback)](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#writetransaction) automatically commits changes after the transaction callback is completed if [tx.rollback()](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/db/DBAdapter.ts#L53) has not explicitly been called. If an exception is thrown in the callback then changes are automatically rolled back.
 
 
 ```js
@@ -122,7 +122,7 @@ return (
 
 ## Send changes in local data to your backend service
 
-Override [uploadData](https://powersync-ja.github.io/powersync-js/react-native-sdk/interfaces/PowerSyncBackendConnector#uploaddata) to send local updates to your backend service.
+Override [uploadData](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/client/connection/PowerSyncBackendConnector.ts#L24) to send local updates to your backend service.
 
 ```js
 // Implement the uploadData method in your backend connector


### PR DESCRIPTION
## Description
We removed interfaces from the JS docs so the `uploadData` function doesn't exist there anymore because `PowerSyncBackendConnector` is an interface. Further links were found that no longer exist. The links have been replaced with references in Github.