### PR TITLE
fix: doc circular loop

### DIFF
--- a/installation/app-backend-setup/writing-client-changes.mdx
+++ b/installation/app-backend-setup/writing-client-changes.mdx
@@ -3,13 +3,15 @@ title: "Writing Client Changes"
 description: "Your app backend needs to expose an API endpoint to write changes to your backend database that are received from the PowerSync client."
 ---
 
+<Info>
+  The backend receives the changes from your `uploadData` function in the `PowerSyncBackendConnector` on the client.
+</Info>
+
 This could be:
 
 1. A single endpoint accepting a batch of changes from the client, with minimal client-side processing.
 2. Separate endpoints based on the types of changes.
 3. A combination of the above.
-
-For details of the client-side interface to your backend, see [Integrating With Your Backend](/installation/client-side-setup/integrating-with-your-backend).
 
 <Warning>
 It's important that your endpoint be blocking/synchronous with underlying Postgres or MongoDB writes.
@@ -63,3 +65,11 @@ For details on handling write conflicts, see:
     horizontal
   />
 </CardGroup>
+
+### Example implementations
+
+We have some example backend implementations that you can use as a guide for your implementation:
+
+#### <Icon icon="js" iconType="solid" size="24"/> [NodeJS](https://github.com/powersync-ja/powersync-nodejs-backend-todolist-demo)
+
+#### <Icon icon="python" iconType="solid" size="24"/> [Django](https://github.com/powersync-ja/powersync-django-backend-todolist-demo)


### PR DESCRIPTION
## Description
* Removed doc circular loop in favour of an info box (not sure how else to avoid this loop?)
* Added example implementation for backends