### PR TITLE
Add PowerSyncDatabase Flags usage example

### DIFF
--- a/client-sdk-references/javascript-web/usage-examples.mdx
+++ b/client-sdk-references/javascript-web/usage-examples.mdx
@@ -389,8 +389,8 @@ Logs will include detailed insights into database operations and synchronization
 
 ### Recommendations
 
-1. **Enable `enableMultiTabs`** if your application requires seamless data sharing across multiple tabs.
+1. **Set `enableMultiTabs`** to `true` if your application requires seamless data sharing across multiple tabs.
 2. **Set `useWebWorker`** to `true` for efficient database operations using web workers.
-3. **Use `broadcastLogs`** during development to troubleshoot and monitor database and sync operations.
-4. **Enable `disableSSRWarning`** when running in SSR mode to avoid unnecessary console warnings.
+3. **Set `broadcastLogs`** to `true` during development to troubleshoot and monitor database and sync operations.
+4. **Set `disableSSRWarning`** to `true` when running in SSR mode to avoid unnecessary console warnings.
 5. **Test combinations** of flags to validate their behavior in your application's specific use case.


### PR DESCRIPTION
This PR adds usage examples of the PowerSyncDatabase Flags to the JS Web Usage Examples.

Thought the use of params would be nice for the flags:
![image](https://github.com/user-attachments/assets/0dacc6d5-6359-4483-97d3-a827de427786)
