### PR TITLE
Atlas: Be more explicit with required permissions

### DIFF
--- a/installation/database-setup.mdx
+++ b/installation/database-setup.mdx
@@ -355,9 +355,10 @@ read@<your_database>
 ```
 
 To allow PowerSync to automatically enable [`changeStreamPreAndPostImages`](#post-images) on
-replicated collections, instead use:
+replicated collections, additionally add the `dbAdmin` permission:
 
 ```
+readWrite@<your_database>._powersync_checkpoints
 dbAdmin@<your_database>
 ```
 
@@ -369,7 +370,7 @@ readAnyDatabase@admin
 
 ### Permissions required - Self-hosted
 
-For self-hosted MongoDB, PowerSync requires the `find` and `changeStream` permissions on the database being replicated.
+For self-hosted MongoDB, PowerSync requires the `find`, `changeStream` and `listCollections` permissions on the database being replicated.
 
 PowerSync also requires `createCollection`, `dropCollection`, `insert`, `update`, and `remove` permissions to the `_powersync_checkpoints` collection.
 


### PR DESCRIPTION
`dbAdmin` does not include write permissions, so it is required _in addition to_ `readWrite` on `_powersync_checkpoints`.