### PR TITLE
chore: change examples to use cursor get by column name:

### DIFF
--- a/client-sdk-references/kotlin-multiplatform.mdx
+++ b/client-sdk-references/kotlin-multiplatform.mdx
@@ -242,9 +242,9 @@ fun watchCustomers(): Flow<List<User>> {
     // TODO: implement your UI based on the result set
     return database.watch("SELECT * FROM customers", mapper = { cursor ->
         User(
-            id = cursor.getString("id")!!,
-            name = cursor.getString("name")!!,
-            email = cursor.getString("email")!!
+            id = cursor.getString("id"),
+            name = cursor.getString("name"),
+            email = cursor.getString("email")
         )
     })
 }

--- a/client-sdk-references/kotlin-multiplatform/usage-examples.mdx
+++ b/client-sdk-references/kotlin-multiplatform/usage-examples.mdx
@@ -30,9 +30,9 @@ fun watchCustomers(): Flow<List<User>> {
     // TODO: implement your UI based on the result set
     return database.watch("SELECT * FROM customers", mapper = { cursor ->
         User(
-            id = cursor.getString("id")!!,
-            name = cursor.getString("name")!!,
-            email = cursor.getString("email")!!
+            id = cursor.getString("id"),
+            name = cursor.getString("name"),
+            email = cursor.getString("email")
         )
     })
 }

--- a/client-sdk-references/swift.mdx
+++ b/client-sdk-references/swift.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Overview"
 <CardGroup cols={3}>
   <Card title="Source Code" icon="github" href="https://github.com/powersync-ja/powersync-swift/">
   Refer to the powersync-swift repo on GitHub.
-  </Card>  
+  </Card>
   <Card title="API Reference (Coming soon)" icon="book" href="">
   A full API Reference for this SDK is not yet available. This is planned for the V1 release.
   </Card>
@@ -249,10 +249,10 @@ func getList(_ id: String) async throws {
         parameters: [id],
         mapper: { cursor in
             ListContent(
-                id: cursor.getString(name: "id")!,
-                name: cursor.getString(name: "name")!,
-                createdAt: cursor.getString(name: "created_at")!,
-                ownerId: cursor.getString(name: "owner_id")!
+                id: try cursor.getString(name: "id")!,
+                name: try cursor.getString(name: "name")!,
+                createdAt: try cursor.getString(name: "created_at")!,
+                ownerId: try cursor.getString(name: "owner_id")!
             )
         }
     )
@@ -271,10 +271,10 @@ func getLists() async throws {
         parameters: [],
         mapper: { cursor in
             ListContent(
-                id: cursor.getString(name: "id")!,
-                name: cursor.getString(name: "name")!,
-                createdAt: cursor.getString(name: "created_at")!,
-                ownerId: cursor.getString(name: "owner_id")!
+                id: try cursor.getString(name: "id")!,
+                name: try cursor.getString(name: "name")!,
+                createdAt: try cursor.getString(name: "created_at")!,
+                ownerId: try cursor.getString(name: "owner_id")!
             )
         }
     )
@@ -293,10 +293,10 @@ func watchLists(_ callback: @escaping (_ lists: [ListContent]) -> Void ) async {
         parameters: [],
         mapper: { cursor in
             ListContent(
-                id: cursor.getString(name: "id")!,
-                name: cursor.getString(name: "name")!,
-                createdAt: cursor.getString(name: "created_at")!,
-                ownerId: cursor.getString(name: "owner_id")!
+                id: try cursor.getString(name: "id")!,
+                name: try cursor.getString(name: "name")!,
+                createdAt: try cursor.getString(name: "created_at")!,
+                ownerId: try cursor.getString(name: "owner_id")!
             )
         }
     ) {

--- a/migration-guides/mongodb-atlas.mdx
+++ b/migration-guides/mongodb-atlas.mdx
@@ -367,12 +367,12 @@ Reading data in the application which uses PowerSync is very simple: we use SQLi
          sql: "SELECT * FROM todos",
          mapper: { cursor in
                TodoContent(
-                  list_id: cursor.getString(name: "list_id")!,
-                  description: cursor.getString(name: "description")!,
-                  completed: cursor.getBoolean(name: "completed")!,
-                  created_by: cursor.getString(name: "created_by")!,
-                  completed_by: cursor.getString(name: "completed_by")!,
-                  completed_at: cursor.getString(name: "completed_at")!
+                  list_id: try cursor.getString(name: "list_id"),
+                  description: try cursor.getString(name: "description"),
+                  completed: try cursor.getBooleanOptional(name: "completed"),
+                  created_by: try cursor.getString(name: "created_by"),
+                  completed_by: try cursor.getStringOptional(name: "completed_by"),
+                  completed_at: try cursor.getStringOptional(name: "completed_at")
                )
          }
       )


### PR DESCRIPTION
## Description
Update the docs to showcase the new way to use the cursor by using the column name instead of the index number 