### PR TITLE
[KMP] Fix Transaction example

### DIFF
--- a/client-sdk-references/kotlin-multiplatform.mdx
+++ b/client-sdk-references/kotlin-multiplatform.mdx
@@ -256,8 +256,8 @@ The `execute` method executes a write query (INSERT, UPDATE, DELETE) and returns
 
 ```kotlin
 suspend fun insertCustomer(name: String, email: String) {
-    database.writeTransaction {
-        database.execute(
+    database.writeTransaction { tx ->
+        tx.execute(
             sql = "INSERT INTO customers (id, name, email) VALUES (uuid(), ?, ?)",
             parameters = listOf(name, email)
         )
@@ -281,8 +281,8 @@ suspend fun deleteCustomer(id: String? = null) {
             }
         ) ?: return
 
-    database.writeTransaction {
-        database.execute(
+    database.writeTransaction { tx ->
+        tx.execute(
             sql = "DELETE FROM customers WHERE id = ?",
             parameters = listOf(targetId)
         )


### PR DESCRIPTION
# Overview

The current KMP SDK transaction example API is outdated and not functional. A transaction context has been supplied to transaction callbacks since the Beta release. This context should be used for database operations. 

This updates transaction examples to use the transaction context for DB operations instead of the root database instance.