### PR TITLE
BYPASSRLS

### DIFF
--- a/installation/database-setup.mdx
+++ b/installation/database-setup.mdx
@@ -61,7 +61,7 @@ We have documented steps for some hosting providers:
 
     ```sql
     -- SQL to create powersync user
-    CREATE ROLE powersync_role WITH LOGIN PASSWORD 'myhighlyrandompassword' BYPASSRLS;
+    CREATE ROLE powersync_role WITH BYPASSRLS LOGIN PASSWORD 'myhighlyrandompassword';
 
     -- Allow the role to perform replication tasks
     GRANT rds_replication TO powersync_role;

--- a/snippets/postgres-powersync-user.mdx
+++ b/snippets/postgres-powersync-user.mdx
@@ -1,6 +1,6 @@
 ```sql
 -- Create a role/user with replication privileges for PowerSync
-CREATE ROLE powersync_role WITH REPLICATION LOGIN PASSWORD 'myhighlyrandompassword' BYPASSRLS;
+CREATE ROLE powersync_role WITH REPLICATION BYPASSRLS LOGIN PASSWORD 'myhighlyrandompassword';
 -- Set up permissions for the newly created role
 -- Read-only (SELECT) access is required
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO powersync_role;  


### PR DESCRIPTION
We typically had two cases before:
1. Supabase projects typically use RLS, but typically used the `postgres` "super-user" (not quite, but close).
2. Other projects typically used a custom `powersync_role` with less privileges, but no RLS.

The issue comes in if you combine the two: If you use a normal `powersync_role` user _and_ have RLS enabled, then suddenly powersync sees 0 rows during initial replication. There isn't even an error, but there is no data to replicate until you start modifying rows again (logical replication still works).

The fix here is to just add the BYPASSRLS attribute for the role. This updates the docs for all cases, not just Supabase, in case others also use RLS.

For existing roles, you do this:

```sql
ALTER ROLE powersync_role BYPASSRLS
```