### PR TITLE
Fix better-sqlite3 reference for node SDK

### DIFF
--- a/snippets/node/installation.mdx
+++ b/snippets/node/installation.mdx
@@ -22,30 +22,30 @@ Add the [PowerSync Node NPM package](https://www.npmjs.com/package/@powersync/no
 
 **Required peer dependencies**
   
-This SDK requires [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) as a peer dependency:
+This SDK requires [`@powersync/better-sqlite3`](https://www.npmjs.com/package/@powersync/better-sqlite3) as a peer dependency:
 
 <Tabs>
   <Tab title="npm">
     ```bash
-    npm install better-sqlite3
+    npm install @powersync/better-sqlite3
     ```
   </Tab>
 
   <Tab title="yarn">
     ```bash
-    yarn add better-sqlite3
+    yarn add @powersync/better-sqlite3
     ```
   </Tab>
 
   <Tab title="pnpm">
     ```bash
-    pnpm install better-sqlite3
+    pnpm install @powersync/better-sqlite3
     ```
   </Tab>
 </Tabs>
 
 **Common installation issues**
 
-The `better-sqlite` package requires native compilation, which depends on certain system tools. This compilation process is handled by `node-gyp` and may fail if required dependencies are missing or misconfigured.
+The `@powersync/better-sqlite` package requires native compilation, which depends on certain system tools. This compilation process is handled by `node-gyp` and may fail if required dependencies are missing or misconfigured.
 
 Refer to the [PowerSync Node package README](https://www.npmjs.com/package/@powersync/node) for more details.


### PR DESCRIPTION
The Node SDK uses a fork (`@powersync/better-sqlite3`) insteaed of the original package (`better-sqlite3`). This patches references in the documentation to suggest installing the correct package.