### PR TITLE
Updated .NET demo app examples.

### DIFF
--- a/resources/demo-apps-example-projects.mdx
+++ b/resources/demo-apps-example-projects.mdx
@@ -99,13 +99,15 @@ This page showcases example projects organized by platform and backend technolog
   #### Supabase Backend
 
   * [To-Do List App](https://github.com/powersync-ja/powersync-swift/tree/main/Demo)
-    * * Demonstrates [File/Attachment Handling](/usage/use-case-examples/attachments-files)
+    * Demonstrates [File/Attachment Handling](/usage/use-case-examples/attachments-files)
   </Accordion>
 
   <Accordion title=".NET (alpha)" icon="microsoft">
   #### Examples
 
   * [CLI Application](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/CommandLine)
+    * Includes an optional [Supabase connector](https://github.com/powersync-ja/powersync-dotnet/blob/main/demos/CommandLine/SupabaseConnector.cs)
+  * [WPF To-Do list App](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/WPF)
   </Accordion>
 
   <Accordion title="Backend Examples" icon="screwdriver-wrench">
@@ -126,6 +128,10 @@ This page showcases example projects organized by platform and backend technolog
   
   * [Rails Backend for GoToFun App](https://github.com/powersync-ja/powersync-rails-flutter-demo/tree/main/gotofun-backend)
     * For use with: Flutter [GoToFun App](https://github.com/powersync-ja/powersync-rails-flutter-demo/tree/main/gotofun-app)
+
+  #### .NET
+  
+  * [.NET Backend for To-Do List App](https://github.com/powersync-ja/powersync-dotnet-backend-demo)
   </Accordion>
 
   <Accordion title="Self-Hosting Examples" icon="desktop">


### PR DESCRIPTION
Updated .NET demo app examples to include new WPF To-Do List demo and the CLI App Supabase connector. Added the .NET demo backend project to the Backend Examples section. Also fixed double bullet point in the Swift To-Do List.