### PR TITLE
Add docs on using FlutterFlow with custom connector

### DIFF
--- a/integration-guides/flutterflow-+-powersync.mdx
+++ b/integration-guides/flutterflow-+-powersync.mdx
@@ -671,6 +671,48 @@ This allows you to customize how individual values are represented for Postgres.
 column of the `lists` table is decoded as JSON so that it's uploaded as a proper array while being stored
 as a list locally.
 
+## Custom backend connectors
+
+To enable an easy setup, the PowerSync FlutterFlow library integrates with Supabase by default. This means
+that as long as you use Supabase for authentication in your app, PowerSync will automatically connect as
+soon as users log in, and can automatically upload local writes to a Supabase database.
+
+For apps that don't use Supabase, you can disable this default behavior and instead rely on your own
+backend connectors.
+For this, create your own custom action (e.g. `applyPowerSyncOptions`). It's important that this action runs
+before anything else in your app uses PowerSync, so add this action to your `main.dart` as a final action.
+
+```dart
+import 'package:power_sync_b0w5r9/custom_code/actions/initialize_power_sync.dart';
+import 'package:powersync/powersync.dart' as ps;
+
+Future applyPowerSyncOptions() async {
+  // Disable the default Supabase integration
+  powerSyncOptions.useSupabaseConnector = false;
+  final db = await getOrInitializeDatabase();
+
+  // TODO: Write your own connector and call connect/disconnect when a user logs
+  // in.
+  db.connect(connector: _MyCustomConnector());
+}
+
+final class _MyCustomConnector extends ps.PowerSyncBackendConnector {
+  @override
+  Future<ps.PowerSyncCredentials?> fetchCredentials() {
+    // TODO: implement fetchCredentials
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> uploadData(ps.PowerSyncDatabase database) {
+    // TODO: implement uploadData
+    throw UnimplementedError();
+  }
+}
+```
+
+For more information on writing backend connectors, see [integrating with your backend](/client-sdk-references/flutter#3-integrate-with-your-backend).
+
 ## Known Issues, Limitations and Gotchas
 
 Below is a list of known issues and limitations.


### PR DESCRIPTION
The FlutterFlow library now has an opt-in option to disable the Supabase integration, allowing developers to write their own connectors. This means they have to take care of writing the connectors and connecting at the appropriate time. This adds a section to the integration guide explaining the option.