### PR TITLE
Updates to .Net docs, generating a self-host token and .complete() note

### DIFF
--- a/client-sdk-references/dotnet.mdx
+++ b/client-sdk-references/dotnet.mdx
@@ -19,9 +19,9 @@ import DotNetInstallation from '/snippets/dotnet/installation.mdx';
     A full API Reference for this SDK is not yet available. This is planned for a future release.
   </Card>
 
-  <Card title="Example App" icon="code" href="https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/CommandLine">
-    A small CLI app showcasing bidirectional sync.
-  </Card>
+    <Card title="Example Projects" icon="code" href="/resources/demo-apps-example-projects#net-alpha">
+        Gallery of example projects/demo apps built with .NET and PowerSync.
+    </Card>
 </CardGroup>
 
 <Warning>

--- a/installation/app-backend-setup/writing-client-changes.mdx
+++ b/installation/app-backend-setup/writing-client-changes.mdx
@@ -49,6 +49,10 @@ We do however recommend the following:
     1. Including the error details in the `2xx` response.
     2. Writing the error(s) into a separate table/collection that is synced to the client, so that the client/user can handle the error(s).
 
+<Note>
+If you don't call `.complete()` on an operation, it will remain in the queue and continue to be retried. This may be intentional to maintain consistency with your remote database, but be aware that incomplete operations will prevent the queue from progressing past that point.
+</Note>
+
 For details on approaches, see:
 
 <CardGroup>

--- a/resources/demo-apps-example-projects.mdx
+++ b/resources/demo-apps-example-projects.mdx
@@ -99,13 +99,15 @@ This page showcases example projects organized by platform and backend technolog
   #### Supabase Backend
 
   * [To-Do List App](https://github.com/powersync-ja/powersync-swift/tree/main/Demo)
-    * * Demonstrates [File/Attachment Handling](/usage/use-case-examples/attachments-files)
+    * Demonstrates [File/Attachment Handling](/usage/use-case-examples/attachments-files)
   </Accordion>
 
   <Accordion title=".NET (alpha)" icon="microsoft">
   #### Examples
 
   * [CLI Application](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/CommandLine)
+    * Includes an optional [Supabase connector](https://github.com/powersync-ja/powersync-dotnet/blob/main/demos/CommandLine/SupabaseConnector.cs)
+  * [WPF To-Do list App](https://github.com/powersync-ja/powersync-dotnet/tree/main/demos/WPF)
   </Accordion>
 
   <Accordion title="Backend Examples" icon="screwdriver-wrench">
@@ -126,6 +128,10 @@ This page showcases example projects organized by platform and backend technolog
   
   * [Rails Backend for GoToFun App](https://github.com/powersync-ja/powersync-rails-flutter-demo/tree/main/gotofun-backend)
     * For use with: Flutter [GoToFun App](https://github.com/powersync-ja/powersync-rails-flutter-demo/tree/main/gotofun-app)
+
+  #### .NET
+  
+  * [.NET Backend for To-Do List App](https://github.com/powersync-ja/powersync-dotnet-backend-demo)
   </Accordion>
 
   <Accordion title="Self-Hosting Examples" icon="desktop">

--- a/tutorials/self-host/generate-dev-token.mdx
+++ b/tutorials/self-host/generate-dev-token.mdx
@@ -41,7 +41,7 @@ Development tokens can be generated via either
         # Client (application end user) authentication settings
         client_auth:
             # JWKS URIs can be specified here
-            jwks_uri: !env PS_JWKS_URL
+            jwks_uri: !env PS_JWKS_URL # Not applicable for Supabase
             jwks:
                 keys:
                     - kty: 'oct'

--- a/usage/sync-rules/guide-many-to-many-and-join-tables.mdx
+++ b/usage/sync-rules/guide-many-to-many-and-join-tables.mdx
@@ -106,7 +106,7 @@ JOIN posts ON posts.id = comments.post_id
 WHERE board_id = bucket.board_id
 ```
 
-Unfortunately, joins are not supported in PowerSync's Sync Rules. Instead, we denormalize the data to add a direct foreign key relationship between comments and boards: (Postgres example)
+Unfortunately, [JOINS](/usage/sync-rules/parameter-queries#restrictions) are not supported in PowerSync's Sync Rules. Instead, we denormalize the data to add a direct foreign key relationship between comments and boards: (Postgres example)
 
 ```sql
 ALTER TABLE comments ADD COLUMN board_id uuid;


### PR DESCRIPTION
- .Net page now takes users to all .Net demo app examples instead of to the CLI demo repo.
- Added a note outlining the importance and potential repercussions of not calling .complete() in the `uploadData()` function.
- Added a comment next to the JWKS_URL parameter in the config.yaml file highlighting that it is not applicable if using Supabase
- Added link on "JOINS" to redirect to parameter query restrictions in the many-to-many sync rule guide.

