### PR TITLE
Clarify key location in Supabase

### DIFF
--- a/integration-guides/flutterflow-+-powersync.mdx
+++ b/integration-guides/flutterflow-+-powersync.mdx
@@ -112,7 +112,7 @@ This guide walks you through building a basic item management app from scratch a
 
 1. Create a new Blank project in FlutterFlow.
 2. Under **"App Settings" -> "Integrations"**, enable "Supabase".
-   1. Enter your Supabase "API URL" and public "Anon Key". You can find these under **"Project Settings" -> "API"** in your Supabase dashboard.
+   1. Enter your Supabase "API URL" and public "Anon Key". You can find these under **"Project Settings" -> "API Keys" -> `anon` `public`** in your Supabase dashboard.
    2. Click "Get Schema".
 3. Add the [PowerSync Library](https://marketplace.flutterflow.io/item/dm1cuOwYzDv6yQL2QOFb) to your FlutterFlow account.
 4. Under **"App Settings" -> "Project Dependencies" -> "FlutterFlow Libraries"** click "Add Library".

--- a/integration-guides/supabase-+-powersync.mdx
+++ b/integration-guides/supabase-+-powersync.mdx
@@ -234,7 +234,7 @@ SUPABASE_ANON_KEY=foo
 </CodeGroup>
 
 
-1. In the relevant config file, replace the values for `supabaseUrl` and `supabaseAnonKey` (you can find these under **"Project Settings"** \-> **"API"** in your Supabase dashboard — under the "URL" section, and `anon` `key` under "Project API keys")
+1. In the relevant config file, replace the values for `supabaseUrl` and `supabaseAnonKey` (you can find these under **"Project Settings" -> "API Keys"** in your Supabase dashboard — `anon` `public` under "API keys")
 2. For the value of `powersyncUrl`, click the copy icon on your instance to copy its URL:
 
 <Frame>

--- a/snippets/supabase-database-connection.mdx
+++ b/snippets/supabase-database-connection.mdx
@@ -19,7 +19,7 @@
   </Frame>
 7. Verify your setup by clicking **Test Connection** and resolve any errors.
 8. Click **Next**.
-9. PowerSync will detect the Supabase connection and prompt you to enable Supabase auth. To enable it, copy your JWT Secret from the Supabase Dashboard's API settings and paste it here:
+9. PowerSync will detect the Supabase connection and prompt you to enable Supabase auth. To enable it, copy your JWT Secret from the Supabase Dashboard's API settings (available under **"Configuration" -> "Data API"**) and paste it here:
     <img src="/images/installation/overview-supabase-auth.png" width="60%" />
 10. Click **Enable Supabase auth** to finalize your connection settings.
 


### PR DESCRIPTION
1. The keys page in Supabase has been renamed to "API keys", the anonymous key is now available under the `anon` `public` labels.
2. The JWT secret is available under a page named "API Settings", but that page is called "Data API" in the Supabase sidebar. Since that's not exactly obvious, I've added the exact location to the docs.