### PR TITLE
We're not using kmmbridge anymore

### DIFF
--- a/client-sdk-references/swift.mdx
+++ b/client-sdk-references/swift.mdx
@@ -20,7 +20,7 @@ import SwiftInstallation from '/snippets/swift/installation.mdx';
 
 ## Kotlin Multiplatform -> Swift SDK
 
-The PowerSync Swift SDK makes use of the [PowerSync Kotlin Multiplatform SDK](https://github.com/powersync-ja/powersync-kotlin) with the API tool [SKIE](https://skie.touchlab.co/) and KMMBridge under the hood to help generate and publish a Swift package. The Swift SDK abstracts the Kotlin SDK behind pure Swift Protocols, enabling us to fully leverage Swift's native features and libraries. Our ultimate goal is to deliver a Swift-centric experience for developers.
+The PowerSync Swift SDK makes use of the [PowerSync Kotlin Multiplatform SDK](https://github.com/powersync-ja/powersync-kotlin) with the API tool [SKIE](https://skie.touchlab.co/) under the hood to help generate and publish a Swift package. The Swift SDK abstracts the Kotlin SDK behind pure Swift Protocols, enabling us to fully leverage Swift's native features and libraries. Our ultimate goal is to deliver a Swift-centric experience for developers.
 
 
 ### SDK Features


### PR DESCRIPTION
This removes an outdated mention of kmmbridge on the docs (for the stable SDKs, we've switched to a custom publishing step to simplify the publishing logic from Kotlin to Swift).