### PR TITLE
Adds missing import to React Native & Expo sdk intro docs

### DIFF
--- a/client-sdk-references/react-native-and-expo.mdx
+++ b/client-sdk-references/react-native-and-expo.mdx
@@ -187,7 +187,7 @@ Accordingly, the connector must implement two methods:
 **Example**:
 
 ```typescript powersync/Connector.ts
-import { PowerSyncBackendConnector, UpdateType  } from "@powersync/react-native"
+import { PowerSyncBackendConnector, AbstractPowerSyncDatabase, UpdateType } from "@powersync/react-native"
 
 export class Connector implements PowerSyncBackendConnector {
   /**


### PR DESCRIPTION
In the [Instantiate the PowerSync Database](https://docs.powersync.com/client-sdk-references/react-native-and-expo#2-instantiate-the-powersync-database) section of the React Native & Expo docs, the `powersync/Connector.ts` example is missing an import for `AbstractPowerSyncDatabase`