### PR TITLE
Raw tables: Mention Swift support

### DIFF
--- a/usage/use-case-examples/raw-tables.mdx
+++ b/usage/use-case-examples/raw-tables.mdx
@@ -24,6 +24,7 @@ Raw tables were introduced in the following versions of our client SDKs:
 - __JavaScript__ (Node: `0.8.0`, React-Native: `1.23.0`, Web: `1.24.0`)
 - __Dart__: Version 1.15.0 of `package:powersync`.
 - __Kotlin__: Version 1.3.0
+- __Swift__: Version 1.3.0
 
 Also note that raw tables are only supported by the new [Rust-based sync client](https://releases.powersync.com/announcements/improved-sync-performance-in-our-client-sdks), which is currently opt-in.
 </Note>
@@ -175,11 +176,29 @@ val schema = Schema(listOf(
 </Tab>
 
 <Tab title="Swift">
-Unfortunately, raw tables are not available in the Swift SDK yet.
+To define a raw table, include it in the list of tables passed to the `Schema`:
+
+```Swift
+let lists = RawTable(
+    name: "todo_lists",
+    put: PendingStatement(
+        sql: "INSERT OR REPLACE INTO todo_lists (id, created_by, title, content) VALUES (?, ?, ?, ?)",
+        parameters: [.id, .column("created_by"), .column("title"), .column("content")]
+    ),
+    delete: PendingStatement(
+        sql: "DELETE FROM todo_lists WHERE id = ?",
+        parameters: [.id],
+    ),
+)
+
+let schema = Schema(lists)
+```
 </Tab>
 
 <Tab title=".NET">
 Unfortunately, raw tables are not available in the .NET SDK yet.
+
+------
 </Tab>
 
 </Tabs>


### PR DESCRIPTION
The upcoming 1.3.0 version of the PowerSync Swift SDK will include support for raw tables. This updates the documentation to include the minimum version and describes how raw tables are defined.