### PR TITLE
Fix installation guide for Kotlin SDK

### DIFF
--- a/snippets/kotlin-multiplatform/installation.mdx
+++ b/snippets/kotlin-multiplatform/installation.mdx
@@ -5,9 +5,9 @@ kotlin {
     //...
     sourceSets {
         commonMain.dependencies {
-            api("com.powersync:core:$powersyncVersion")
+            implementation("com.powersync:core:$powersyncVersion")
             // If you want to use the Supabase Connector, also add the following:
-            implementation("com.powersync:connectors:$powersyncVersion")
+            implementation("com.powersync:connector-supabase:$powersyncVersion")
         }
         //...
     }


### PR DESCRIPTION
- The Supabase connector module is [named `connector-supabase`](https://central.sonatype.com/artifact/com.powersync/connector-supabase), not `connectors`.
- There's generally no reason for the `api` configuration, unless users explicitly use powersync in the API of an internal library. We can expect users to be aware of that though, and `implementation` is generally the right configuration to use.