### PR TITLE
Kotlin SDK: Remove websocket docs

### DIFF
--- a/client-sdk-references/kotlin-multiplatform.mdx
+++ b/client-sdk-references/kotlin-multiplatform.mdx
@@ -345,33 +345,6 @@ These instructions are decoded by our SDKs, and on Kotlin there are two implemen
 To enable the Rust client, pass `SyncOptions(newClientImplementation = true)` as a second parameter when
 [connecting](https://powersync-ja.github.io/powersync-kotlin/core/com.powersync/-power-sync-database/connect.html).
 
-### Connection Methods
-
-This SDK supports two methods for streaming sync commands:
-
-1. **WebSocket (currently experimental)**
-   - The implementation leverages RSocket for handling reactive socket streams.
-   - Back-pressure is effectively managed through client-controlled command requests.
-   - Sync commands are transmitted efficiently as BSON (binary) documents.
-   - Enabling websocket support requires the new client implementation.
-2. **HTTP Streaming (default)**
-   - This is the original implementation method.
-   - This method sends data as text (JSON) instead of BSON.
-
-By default, the `PowerSyncDatabase.connect()` method uses HTTP streams.
-You can optionally specify the `connectionMethod` to override this:
-
-```Kotlin
-// HTTP streaming (default)
-powerSync.connect(connector)
-
-// WebSockets (experimental)
-powerSync.connect(connector, SyncOptions(
-    newClientImplementation = true,
-    method = ConnectionMethod.WebSocket(),
-))
-```
-
 ## ORM Support
 
 ORM support is not yet available, we are still investigating options to integrate the SDK with Room and SQLDelight.


### PR DESCRIPTION
Since we're about to remove the websocket connection option in 1.3.1, also remove it from the documentation site.