### PR TITLE
Remove "Hello PowerSync" demo link

### DIFF
--- a/resources/demo-apps-example-projects.mdx
+++ b/resources/demo-apps-example-projects.mdx
@@ -86,8 +86,6 @@ This page showcases example projects organized by platform and backend technolog
   <Accordion title="Kotlin Multiplatform" icon="k">
   #### Supabase Backend
 
-  * [Hello PowerSync](https://github.com/powersync-ja/powersync-kotlin/tree/main/demos/hello-powersync) - Minimal starter app
-    * Supports Android, iOS, and Desktop (JVM) targets
   * [To-Do List App](https://github.com/powersync-ja/powersync-kotlin/tree/main/demos/supabase-todolist)
     * Supports Android, iOS, and Desktop (JVM) targets
     * Includes a guide for [implementing background sync on Android](https://github.com/powersync-ja/powersync-kotlin/blob/main/demos/supabase-todolist/docs/BackgroundSync.md)


### PR DESCRIPTION
This removes references to the "Hello PowerSync" demo we're about to remove from the repository of the Kotlin SDK repository.