### PR TITLE
fix: add UTC timezone designator to mongo date mapping

### DIFF
--- a/usage/sync-rules/types.mdx
+++ b/usage/sync-rules/types.mdx
@@ -53,7 +53,7 @@ There is no dedicated boolean data type. Boolean values are represented as `1` (
 | ObjectId           | text                           | Lower-case hex string |
 | UUID               | text                           | Lower-case hex string |
 | Boolean            | integer                        | 1 for true, 0 for false |
-| Date               | text                           | Format: `YYYY-MM-DD hh:mm:ss.sss` |
+| Date               | text                           | Format: `YYYY-MM-DD hh:mm:ss.sssZ` |
 | Null               | null                           |  |
 | Binary             | blob                           | Cannot sync directly to client — convert to hex or base64 first. See [Operators & Functions](/usage/sync-rules/operators-and-functions). |
 | Regular Expression | text                           | JSON text in the format `{"pattern":"...","options":"..."}` |


### PR DESCRIPTION
According to the following [thread](https://discord.com/channels/1138230179878154300/1404798302951706716) and testing on my side. Dates include the UTC timezone designator (Z) when mapped to the Sqllite database. 