### PR TITLE
Add a note explaining the consequences of ID aliases when uploading

### DIFF
--- a/usage/sync-rules/client-id.mdx
+++ b/usage/sync-rules/client-id.mdx
@@ -22,6 +22,10 @@ Custom transformations could also be used for the ID, for example:
 SELECT org_id || '.' || record_id as id FROM my_data
 ```
 
+<Warning>
+    If you want to upload data to a table with a custom record ID, ensure that `uploadData()` isn't blindly using a field named `id` when handling CRUD operations. See the [Sequential ID mapping tutorial](/tutorials/client/data/sequential-id-mapping#update-client-to-use-uuids) for an example where the record ID is aliased to `uuid` on the backend.
+</Warning>
+
 PowerSync does not perform any validation that IDs are unique. Duplicate IDs on a client could occur in any of these scenarios:
 
 1. A non-unique column is used for the ID.


### PR DESCRIPTION
See powersync-ja/powersync-kotlin#247 for context.

Maybe this deserves a spot in `Usage Examples`, but there's a few reasonable transformations for client IDs that aren't simple aliases (e.g. `org_id || '.' || employee_id`). 