### PR TITLE
Saying we're compatible with custom types is misleading

### DIFF
--- a/usage/lifecycle-maintenance/implementing-schema-changes.mdx
+++ b/usage/lifecycle-maintenance/implementing-schema-changes.mdx
@@ -221,6 +221,6 @@ In some cases, the change will have no effect on PowerSync (for example, changin
 
 ## See Also
 
-* [Custom Types, Arrays and JSON](/usage/use-case-examples/custom-types-arrays-and-json)
+* [JSON, Arrays and Custom Types](/usage/use-case-examples/custom-types-arrays-and-json)
 
 * [Deploying Schema Changes](/usage/lifecycle-maintenance/deploying-schema-changes)

--- a/usage/use-case-examples.mdx
+++ b/usage/use-case-examples.mdx
@@ -9,11 +9,11 @@ The following examples are available to help you get started with specific use c
   <Card title="Attachments / Files" icon="file" href="/usage/use-case-examples/attachments-files" horizontal/>
   <Card title="Background Syncing" icon="circle-notch" href="/usage/use-case-examples/background-syncing" horizontal/>
   <Card title="CRDTs" icon="code-merge" href="/usage/use-case-examples/crdts" horizontal/>
-  <Card title="Custom Types, Arrays and JSON" icon="code" href="/usage/use-case-examples/custom-types-arrays-and-json" horizontal/>
   <Card title="Data Encryption" icon="lock" href="/usage/use-case-examples/data-encryption" horizontal/>
   <Card title="Data Pipelines" icon="code-branch" href="/usage/use-case-examples/custom-write-checkpoints" horizontal/>
   <Card title="Full-Text Search" icon="magnifying-glass" href="/usage/use-case-examples/full-text-search" horizontal/>
   <Card title="Infinite Scrolling" icon="scroll" href="/usage/use-case-examples/infinite-scrolling" horizontal/>
+  <Card title="JSON, Arrays and Custom Types" icon="code" href="/usage/use-case-examples/custom-types-arrays-and-json" horizontal/>
   <Card title="Live Queries / Watch Queries" icon="eye" href="/usage/use-case-examples/watch-queries" horizontal/>
   <Card title="Local-only Usage" icon="laptop" href="/usage/use-case-examples/offline-only-usage" horizontal/>
   <Card title="PostGIS" icon="map" href="/usage/use-case-examples/postgis" horizontal/>

--- a/usage/use-case-examples/custom-types-arrays-and-json.mdx
+++ b/usage/use-case-examples/custom-types-arrays-and-json.mdx
@@ -1,84 +1,75 @@
 ---
-title: "Custom Types, Arrays and JSON"
-description: PowerSync is compatible with more advanced types such as arrays and JSON. 
+title: "JSON, Arrays and Custom Types"
+description: PowerSync supports JSON/JSONB and arrays, and can sync other custom types by serializing them to text.
 ---
 
-PowerSync is compatible with advanced Postgres types, including arrays and JSON/JSONB. These types are represented as text columns in the client-side schema. When updating client data, you have the option to replace the entire column value with a string or enable advanced schema features to track more granular changes and include custom metadata.
+PowerSync supports JSON/JSONB and array columns. They are synced as JSON text and can be queried with SQLite JSON functions on the client. Other custom Postgres types can be synced by serializing their values to text in the client-side schema. When updating client data, you have the option to replace the entire column value with a string or enable [advanced schema options](#advanced-schema-options-to-process-writes) to track more granular changes and include custom metadata.
 
-## Advanced Schema Options to Process Writes
+## JSON and JSONB
 
-With arrays and JSON fields, it's common for only part of the value to change during an update. To make handling these writes easier, you can enable advanced schema options that let you track exactly what changed in each row—not just the new state.
+The PowerSync Service treats JSON and JSONB columns as text and provides many helpers for working with JSON in Sync Rules.
 
-- `trackPreviousValues` (or `trackPrevious` in our JS SDKs): Access previous values for diffing custom types, arrays, or JSON fields. Accessible later via `CrudEntry.previousValues`.
-- `trackMetadata`: Adds a `_metadata` column for storing custom metadata. Value of the column is accessible later via `CrudEntry.metadata`.
-- `ignoreEmptyUpdates`: Skips updates when no data has actually changed.
-
-<Note>
-  These advanced schema options are available in the following SDK versions: Flutter v1.13.0, React Native v1.20.1, JavaScript/Web v1.20.1, Kotlin Multiplatform v1.1.0, Swift v1.1.0, and Node.js v0.4.0.
-</Note>
-
-## Custom Types
-
-PowerSync serializes custom types as text. For details, see [types in sync rules](/usage/sync-rules/types).
+**Note:** Native Postgres arrays, JSON arrays, and JSONB arrays are effectively all equivalent in PowerSync.
 
 ### Postgres
 
-Postgres allows developers to create custom data types for columns. For example:
+JSON columns are represented as:
 
 ```sql
-create type location_address AS (
-    street text,
-    city text,
-    state text,
-    zip numeric
-);
+ALTER TABLE todos
+ADD COLUMN custom_payload json;
 ```
 
 ### Sync Rules
 
-Custom type columns are converted to text by the PowerSync Service. A column of type `location_address`, as defined above, would be synced to clients as the following string:
+PowerSync treats JSON columns as text and provides transformation functions in Sync Rules such as `json_extract()`.
 
-`("1000 S Colorado Blvd.",Denver,CO,80211)`
-
-It is not currently possible to extract fields from custom types in Sync Rules, so the entire column must be synced as text.
+```yaml
+bucket_definitions:
+  my_json_todos:
+    # Separate bucket per To-Do list
+    parameters: SELECT id AS list_id FROM lists WHERE owner_id = request.user_id()
+    data:
+      - SELECT * FROM todos WHERE json_extract(custom_payload, '$.json_list') = bucket.list_id
+```
 
 ### Client SDK
 
 **Schema**
 
-Add your custom type column as a `text` column in your client-side schema definition. For advanced update tracking, see [Advanced Schema Options](#advanced-schema-options).
+Add your JSON column as a `text` column in your client-side schema definition. For advanced update tracking, see [Advanced Schema Options](#advanced-schema-options).
 
 <Tabs>
-  <Tab title="JavaScript">
-    ```javascript
-    const todos = new Table(
-      {
-        location: column.text,
-        // ... other columns ...
-      },
-      {
-        // Optionally, enable advanced update tracking options:
-        trackPrevious: true,
-        trackMetadata: true,
-        ignoreEmptyUpdates: true,
-      }
-    );
-    ```
-  </Tab>
   <Tab title="Dart">
     ```dart
     Table(
       name: 'todos',
       columns: [
-        Column.text('location'),
+        Column.text('custom_payload'),
         // ... other columns ...
       ],
-
-      // Optionally, enable advanced update tracking options:
+      // Optionally, enable advanced update tracking options (see details at the end of this page):
       trackPreviousValues: true, 
       trackMetadata: true, 
       ignoreEmptyUpdates: true, 
     )
+    ```
+  </Tab>
+
+  <Tab title="JavaScript">
+    ```javascript
+    const todos = new Table(
+      {
+        custom_payload: column.text,
+        // ... other columns ...
+      },
+      {
+        // Optionally, enable advanced update tracking options (see details at the end of this page):
+        trackPrevious: true,
+        trackMetadata: true,
+        ignoreEmptyUpdates: true,
+      }
+    );
     ```
   </Tab>
 </Tabs>
@@ -88,39 +79,44 @@ Add your custom type column as a `text` column in your client-side schema defini
 You can write the entire updated column value as a string, or, with `trackPreviousValues` enabled, compare the previous and new values to process only the changes you care about:
 
 <Tabs>
-  <Tab title="JavaScript">
-    ```javascript
+  <Tab title="Dart">
+    ```dart
     // Full replacement (basic):
-    await db.execute(
-      'UPDATE todos set location = ?, _metadata = ? WHERE id = ?',
-      ['("1234 Update Street",Denver,CO,80212)', 'op-metadata-example', 'faffcf7a-75f9-40b9-8c5d-67097c6b1c3b']
-    );
+    await db.execute('UPDATE todos set custom_payload = ?, _metadata = ? WHERE id = ?', [
+      '{"foo": "bar", "baz": 123}',
+      'op-metadata-example', // Example metadata value
+      '00000000-0000-0000-0000-000000000000'
+    ]);
 
-    // Diffing custom types in uploadData (advanced):
-    if (op.op === UpdateType.PUT && op.previousValues) {
-      const oldCustomType = op.previousValues['location'] ?? 'null';
-      const newCustomType = op.opData['location'] ?? 'null';
-      const metadata = op.metadata; // Access metadata here
-      // Compare oldCustomType and newCustomType to determine what changed
+    // Diffing columns in uploadData (advanced):
+    // See details about these advanced schema options at the end of this page
+    import 'dart:convert';
+
+    if (op.op == UpdateType.put && op.previousValues != null) {
+      var oldJson = jsonDecode(op.previousValues['custom_payload'] ?? '{}');
+      var newJson = jsonDecode(op.opData['custom_payload'] ?? '{}');
+      var metadata = op.metadata; // Access metadata here
+      // Compare oldJson and newJson to determine what changed
       // Use metadata as needed as you process the upload
     }
     ```
   </Tab>
-  <Tab title="Dart">
-    ```dart
-    // Full replacement (basic):
-    await db.execute('UPDATE todos set location = ?, _metadata = ? WHERE id = ?', [
-      '("1234 Update Street",Denver,CO,80212)',
-      'op-metadata-example', // Example metadata value
-      'faffcf7a-75f9-40b9-8c5d-67097c6b1c3b'
-    ]);
 
-    // Diffing custom types in uploadData (advanced):
-    if (op.op == UpdateType.put && op.previousValues != null) {
-      final oldCustomType = op.previousValues['location'] ?? 'null';
-      final newCustomType = op.opData['location'] ?? 'null';
-      final metadata = op.metadata; // Access metadata here
-      // Compare oldCustomType and newCustomType to determine what changed
+  <Tab title="JavaScript">
+    ```javascript
+    // Full replacement (basic):
+    await db.execute(
+      'UPDATE todos set custom_payload = ?, _metadata = ? WHERE id = ?',
+      ['{"foo": "bar", "baz": 123}', 'op-metadata-example', '00000000-0000-0000-0000-000000000000']
+    );
+
+    // Diffing columns in uploadData (advanced):
+    // See details about these advanced schema options at the end of this page
+    if (op.op === UpdateType.PUT && op.previousValues) {
+      const oldJson = JSON.parse(op.previousValues['custom_payload'] ?? '{}');
+      const newJson = JSON.parse(op.opData['custom_payload'] ?? '{}');
+      const metadata = op.metadata; // Access metadata here
+      // Compare oldJson and newJson to determine what changed
       // Use metadata as needed as you process the upload
     }
     ```
@@ -183,7 +179,7 @@ Add your array column as a `text` column in your client-side schema definition. 
         // ... other columns ...
       },
       {
-        // Optionally, enable advanced update tracking options:
+        // Optionally, enable advanced update tracking options (see details at the end of this page):
         trackPrevious: true,
         trackMetadata: true,
         ignoreEmptyUpdates: true,
@@ -200,7 +196,7 @@ Add your array column as a `text` column in your client-side schema definition. 
         // ... other columns ...
       ],
 
-      // Optionally, enable advanced update tracking options:
+      // Optionally, enable advanced update tracking options (see details at the end of this page):
       trackPreviousValues: true, 
       trackMetadata: true, 
       ignoreEmptyUpdates: true, 
@@ -222,7 +218,8 @@ You can write the entire updated column value as a string, or, with `trackPrevio
       ['["DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF", "ABCDEFAB-ABCD-ABCD-ABCD-ABCDEFABCDEF"]', 'op-metadata-example', '00000000-0000-0000-0000-000000000000']
     );
 
-    // Diffing custom types in uploadData (advanced):
+    // Diffing columns in uploadData (advanced):
+    // See details about these advanced schema options at the end of this page
     if (op.op === UpdateType.PUT && op.previousValues) {
       const oldArray = JSON.parse(op.previousValues['unique_identifiers'] ?? '[]');
       const newArray = JSON.parse(op.opData['unique_identifiers'] ?? '[]');
@@ -241,8 +238,9 @@ You can write the entire updated column value as a string, or, with `trackPrevio
       '00000000-0000-0000-0000-000000000000'
     ]);
 
-    // Diffing custom types in uploadData (advanced):
-    if (op.op == UpdateType.put && op.previousValues != null) {
+    // Diffing columns in uploadData (advanced):
+    // See details about these advanced schema options at the end of this page
+    if (op.op == UpdateType put && op.previousValues != null) {
       final oldArray = jsonDecode(op.previousValues['unique_identifiers'] ?? '[]');
       final newArray = jsonDecode(op.opData['unique_identifiers'] ?? '[]');
       final metadata = op.metadata; // Access metadata here
@@ -257,71 +255,68 @@ You can write the entire updated column value as a string, or, with `trackPrevio
   **Attention Supabase users:** Supabase can handle writes with arrays, but you must convert from string to array using `jsonDecode` in the connector's `uploadData` function. The default implementation of `uploadData` does not handle complex types like arrays automatically.
 </Info>
 
-## JSON and JSONB
+## Custom Types
 
-The PowerSync Service treats JSON and JSONB columns as text and provides many helpers for working with JSON in Sync Rules.
-
-**Note:** Native Postgres arrays, JSON arrays, and JSONB arrays are effectively all equivalent in PowerSync.
+PowerSync serializes custom types as text. For details, see [types in sync rules](/usage/sync-rules/types).
 
 ### Postgres
 
-JSON columns are represented as:
+Postgres allows developers to create custom data types for columns. For example:
 
 ```sql
-ALTER TABLE todos
-ADD COLUMN custom_payload json;
+create type location_address AS (
+    street text,
+    city text,
+    state text,
+    zip numeric
+);
 ```
 
 ### Sync Rules
 
-PowerSync treats JSON columns as text and provides transformation functions in Sync Rules such as `json_extract()`.
+Custom type columns are converted to text by the PowerSync Service. A column of type `location_address`, as defined above, would be synced to clients as the following string:
 
-```yaml
-bucket_definitions:
-  my_json_todos:
-    # Separate bucket per To-Do list
-    parameters: SELECT id AS list_id FROM lists WHERE owner_id = request.user_id()
-    data:
-      - SELECT * FROM todos WHERE json_extract(custom_payload, '$.json_list') = bucket.list_id
-```
+`("1000 S Colorado Blvd.",Denver,CO,80211)`
+
+It is not currently possible to extract fields from custom types in Sync Rules, so the entire column must be synced as text.
 
 ### Client SDK
 
 **Schema**
 
-Add your JSON column as a `text` column in your client-side schema definition. For advanced update tracking, see [Advanced Schema Options](#advanced-schema-options).
+Add your custom type column as a `text` column in your client-side schema definition. For advanced update tracking, see [Advanced Schema Options](#advanced-schema-options).
 
 <Tabs>
-  <Tab title="Dart">
-    ```dart
-    Table(
-      name: 'todos',
-      columns: [
-        Column.text('custom_payload'),
-        // ... other columns ...
-      ],
-      // Optionally, enable advanced update tracking options:
-      trackPreviousValues: true, 
-      trackMetadata: true, 
-      ignoreEmptyUpdates: true, 
-    )
-    ```
-  </Tab>
-
   <Tab title="JavaScript">
     ```javascript
     const todos = new Table(
       {
-        custom_payload: column.text,
+        location: column.text,
         // ... other columns ...
       },
       {
-        // Optionally, enable advanced update tracking options:
+        // Optionally, enable advanced update tracking options (see details at the end of this page):
         trackPrevious: true,
         trackMetadata: true,
         ignoreEmptyUpdates: true,
       }
     );
+    ```
+  </Tab>
+  <Tab title="Dart">
+    ```dart
+    Table(
+      name: 'todos',
+      columns: [
+        Column.text('location'),
+        // ... other columns ...
+      ],
+
+      // Optionally, enable advanced update tracking options (see details at the end of this page):
+      trackPreviousValues: true, 
+      trackMetadata: true, 
+      ignoreEmptyUpdates: true, 
+    )
     ```
   </Tab>
 </Tabs>
@@ -331,42 +326,41 @@ Add your JSON column as a `text` column in your client-side schema definition. F
 You can write the entire updated column value as a string, or, with `trackPreviousValues` enabled, compare the previous and new values to process only the changes you care about:
 
 <Tabs>
-  <Tab title="Dart">
-    ```dart
-    // Full replacement (basic):
-    await db.execute('UPDATE todos set custom_payload = ?, _metadata = ? WHERE id = ?', [
-      '{"foo": "bar", "baz": 123}',
-      'op-metadata-example', // Example metadata value
-      '00000000-0000-0000-0000-000000000000'
-    ]);
-
-    // Diffing custom types in uploadData (advanced):
-    import 'dart:convert';
-
-    if (op.op == UpdateType.put && op.previousValues != null) {
-      var oldJson = jsonDecode(op.previousValues['custom_payload'] ?? '{}');
-      var newJson = jsonDecode(op.opData['custom_payload'] ?? '{}');
-      var metadata = op.metadata; // Access metadata here
-      // Compare oldJson and newJson to determine what changed
-      // Use metadata as needed as you process the upload
-    }
-    ```
-  </Tab>
-
   <Tab title="JavaScript">
     ```javascript
     // Full replacement (basic):
     await db.execute(
-      'UPDATE todos set custom_payload = ?, _metadata = ? WHERE id = ?',
-      ['{"foo": "bar", "baz": 123}', 'op-metadata-example', '00000000-0000-0000-0000-000000000000']
+      'UPDATE todos set location = ?, _metadata = ? WHERE id = ?',
+      ['("1234 Update Street",Denver,CO,80212)', 'op-metadata-example', 'faffcf7a-75f9-40b9-8c5d-67097c6b1c3b']
     );
 
-    // Diffing custom types in uploadData (advanced):
+    // Diffing columns in uploadData (advanced):
+    // See details about these advanced schema options at the end of this page
     if (op.op === UpdateType.PUT && op.previousValues) {
-      const oldJson = JSON.parse(op.previousValues['custom_payload'] ?? '{}');
-      const newJson = JSON.parse(op.opData['custom_payload'] ?? '{}');
+      const oldCustomType = op.previousValues['location'] ?? 'null';
+      const newCustomType = op.opData['location'] ?? 'null';
       const metadata = op.metadata; // Access metadata here
-      // Compare oldJson and newJson to determine what changed
+      // Compare oldCustomType and newCustomType to determine what changed
+      // Use metadata as needed as you process the upload
+    }
+    ```
+  </Tab>
+  <Tab title="Dart">
+    ```dart
+    // Full replacement (basic):
+    await db.execute('UPDATE todos set location = ?, _metadata = ? WHERE id = ?', [
+      '("1234 Update Street",Denver,CO,80212)',
+      'op-metadata-example', // Example metadata value
+      'faffcf7a-75f9-40b9-8c5d-67097c6b1c3b'
+    ]);
+
+    // Diffing columns in uploadData (advanced):
+    // See details about these advanced schema options at the end of this page
+    if (op.op == UpdateType.put && op.previousValues != null) {
+      final oldCustomType = op.previousValues['location'] ?? 'null';
+      final newCustomType = op.opData['location'] ?? 'null';
+      final metadata = op.metadata; // Access metadata here
+      // Compare oldCustomType and newCustomType to determine what changed
       // Use metadata as needed as you process the upload
     }
     ```
@@ -389,3 +383,20 @@ ALTER TABLE todos
 ADD COLUMN custom_locations extended_location[];
 ```
 
+## Advanced Schema Options to Process Writes
+
+With arrays and JSON fields, it's common for only part of the value to change during an update. To make handling these writes easier, you can enable advanced schema options that let you track exactly what changed in each row—not just the new state.
+
+- `trackPreviousValues` (or `trackPrevious` in our JS SDKs): Access previous values for diffing JSON or array fields. Accessible later via `CrudEntry.previousValues`.
+- `trackMetadata`: Adds a `_metadata` column for storing custom metadata. Value of the column is accessible later via `CrudEntry.metadata`.
+- `ignoreEmptyUpdates`: Skips updates when no data has actually changed.
+
+<Note>
+  These advanced schema options are available in the following SDK versions: 
+  - Flutter v1.13.0
+  - React Native v1.20.1
+  - JavaScript/Web v1.20.1
+  - Kotlin Multiplatform v1.1.0
+  - Swift v1.1.0
+  - Node.js v0.4.0.
+</Note>


### PR DESCRIPTION
The content on this page wasn't _wrong_, but we should make clearer that custom types are serialized to text. 

Also, since JSON and Arrays are better supported, move them higher up.