### PR TITLE
Update Privileges required - Self-hosted / Custom Roles

### DIFF
--- a/installation/database-setup.mdx
+++ b/installation/database-setup.mdx
@@ -54,7 +54,7 @@ We have documented steps for some hosting providers:
     <Frame>
       ![](/images/setup-2.png)
     </Frame>
-    
+
     ### 2. Create a PowerSync database user
 
     Create a PowerSync user on Postgres:
@@ -62,10 +62,10 @@ We have documented steps for some hosting providers:
     ```sql
     -- SQL to create powersync user
     CREATE ROLE powersync_role WITH BYPASSRLS LOGIN PASSWORD 'myhighlyrandompassword';
-    
+
     -- Allow the role to perform replication tasks
     GRANT rds_replication TO powersync_role;
-    
+
     -- Set up permissions for the newly created role
     -- Read-only (SELECT) access is required
     GRANT SELECT ON ALL TABLES IN SCHEMA public TO powersync_role;
@@ -168,10 +168,10 @@ We have documented steps for some hosting providers:
     ```sql
       -- Create a publication to replicate tables.
       -- PlanetScale does not support ON ALL TABLES so
-      -- Specify each table you want to sync 
+      -- Specify each table you want to sync
       -- The publication must be named "powersync"
       CREATE PUBLICATION powersync
-      FOR TABLE public.lists, public.todos; 
+      FOR TABLE public.lists, public.todos;
     ```
   </Accordion>
 </AccordionGroup>
@@ -195,11 +195,11 @@ For other providers and self-hosted databases:
 
   ```sql
   -- Check the replication type
-  
+
   SHOW wal_level;
-  
+
   -- Ensure logical replication is enabled
-  
+
   ALTER SYSTEM SET wal_level = logical;
   ```
 
@@ -253,14 +253,13 @@ readAnyDatabase@admin
 
 For self-hosted MongoDB, or for creating custom roles on MongoDB Atlas, PowerSync requires the following privileges/granted actions:
 
-- On the database being replicated: `listCollections`
-- On all collections in the database: `changeStream`
-  - This must apply to the entire database, not individual collections. Specify `collection: ""`
-  - If replicating from multiple databases, this must apply to the entire cluster. Specify `db: ""`
-- On each collection being replicated: `find`
-- On the `_powersync_checkpoints` collection: `createCollection`, `dropCollection`, `find`, `changeStream`, `insert`, `update`, and `remove`
+- `listCollections`: This privilege must be granted on the database being replicated.
+- `find`: This privilege must be granted either at the database level or on specific collections.
+- `changeStream`: This privilege must be granted at the database level (not on individual collections). In MongoDB Atlas, set `collection: ""` or check `Apply to any collection` in MongoDB Atlas if you want to apply this privilege on any collection.
+  - If replicating from multiple databases, this must apply to the entire cluster. Specify `db: ""` or check `Apply to any database` in MongoDB Atlas.
+- For the `_powersync_checkpoints` collection add the following privileges: `createCollection`, `dropCollection`, `find`, `changeStream`, `insert`, `update`, and `remove`
 - To allow PowerSync to automatically enable [`changeStreamPreAndPostImages`](#post-images) on
-  replicated collections, additionally add the `collMod` permission on all replicated collections.
+  replicated collections, additionally add the `collMod` permission on the database and all collections being replicated.
 
 ### Post-Images
 


### PR DESCRIPTION
This PR introduces small wording changes to the Privileges required - Self-hosted / Custom roles Section section under the installation guides. The wording changes are a little more specific based on how the MongoDB Atlas Role Editor UI works and based on feedback directly from MongoDB.

This PR should address comments made on an earlier [PR](https://github.com/powersync-ja/powersync-docs/pull/204) which has been closed as it became very outdated. 

> This appears contradictory to "not individual collections" below - perhaps we can just make this "on the database being replicated"? Or is there a better way to indicate the difference between "find" (can be on the db-level or individual collections) and "changeStream" (must be on the db-level)?

To address this feedback I've made it more specific e.g.

```
- `find`: This privilege must be granted either at the database level or on specific collections.
- `changeStream`: This privilege must be granted at the database level (not on individual collections). In MongoDB Atlas, set `collection: ""` or check `Apply to any collection` in MongoDB Atlas if you want to apply this privilege on any collection.
  - If replicating from multiple databases, this must apply to the entire cluster. Specify `db: ""` or check `Apply to any database` in MongoDB Atlas.
```