### PR TITLE
Fix typo on javascript web page

### DIFF
--- a/client-sdk-references/javascript-web.mdx
+++ b/client-sdk-references/javascript-web.mdx
@@ -24,7 +24,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
   </Card>
 </CardGroup>
 
-### Quick Start
+### Quickstart
 <iframe
     className="w-full aspect-video rounded-xl"
     src="https://www.youtube.com/embed/wAMIeuVxHd0?si=yevqTB7Of4nEYHKT&cc_load_policy=1"


### PR DESCRIPTION
"Quick Start" changed to "Quickstart" to match the way we refer to it on other pages