### PR TITLE
Fix deprecated cloud code syntax

### DIFF
--- a/usage/tools/monitoring-and-alerting.mdx
+++ b/usage/tools/monitoring-and-alerting.mdx
@@ -266,11 +266,11 @@ Every webhook request contains an `x-journey-signature` header, which is a base6
 import { createHmac } from 'crypto';
 
 // Extract the signature from the request headers
-const signature = request.headers['x-journey-signature'];
+const signature = request.header('x-journey-signature');
 
 // Create an HMAC using your webhook secret and the request body
 let verify = createHmac('sha256', '<webhook_secret_here>') // The secret provided during webhook setup
-    .update(Buffer.from(request.rawBody, 'utf-8')) 
+    .update(Buffer.from(request.body, 'utf-8')) 
     .digest('base64');
 
 // Compare the computed HMAC with the signature from the request


### PR DESCRIPTION
Updated cloud code requests to match our Journey App [docs](https://docs.journeyapps.com/reference/cloudcode/triggering-a-cloudcode-task/trigger-cc-via-http#request-and-response-details)