### PR TITLE
Fix typos in Room docs

### DIFF
--- a/client-sdk-references/kotlin-multiplatform/libraries/room.mdx
+++ b/client-sdk-references/kotlin-multiplatform/libraries/room.mdx
@@ -56,12 +56,12 @@ inserts, updates and deletes.
 Let's say you had a table like the following:
 
 ```Kotlin
-@Entity
+@Entity(tableName = "todos")
 data class TodoItem(
     // Note that PowerSync uses textual ids (usually randomly-generated UUIDs)
     @PrimaryKey val id: String
-    val title: String
-    val authorId: String
+    val description: String
+    @ColumnInfo(name="created_by") val authorId: String
 )
 ```
 
@@ -73,16 +73,16 @@ val schema = Schema(
         name = "todos",
         put =
             PendingStatement(
-                "INSERT INTO todo_item (id, title, author_id) VALUES (?, ?, ?)",
+                "INSERT INTO todos (id, description, created_by) VALUES (?, ?, ?)",
                 listOf(
                     PendingStatementParameter.Id,
-                    PendingStatementParameter.Column("title"),
-                    PendingStatementParameter.Column("author_id"),
+                    PendingStatementParameter.Column("description"),
+                    PendingStatementParameter.Column("created_by"),
                 ),
             ),
         delete =
             PendingStatement(
-                "DELETE FROM todo_item WHERE id = ?",
+                "DELETE FROM todos WHERE id = ?",
                 listOf(PendingStatementParameter.Id),
             ),
     ),
@@ -130,7 +130,7 @@ powersync.connect(
 To run queries, you can keep defining Room DAOs in the usual way:
 
 ```Kotlin
-@DAOs
+@Dao
 interface TodoItemsDao {
     @Insert
     suspend fun create(item: TodoItem)


### PR DESCRIPTION
This fixes a few typos in annotations on that page and updates the table definition to be compatible with the schema we suggest in our Supabase setup guide.