### PR TITLE
Update Watched Query UpdateSettings Example

### DIFF
--- a/usage/use-case-examples/watch-queries.mdx
+++ b/usage/use-case-examples/watch-queries.mdx
@@ -427,7 +427,7 @@ Update query parameters to affect all subscribers of the query:
 ```javascript
 // Updates to query parameters can be performed in a single place, affecting all subscribers
 sharedListsQuery.updateSettings({
-  query: { sql: 'SELECT * FROM lists WHERE state = ?', parameters: ['canceled'] }
+  query: new GetAllQuery({ sql: 'SELECT * FROM lists WHERE state = ?', parameters: ['canceled'] })
 });
 ```
 


### PR DESCRIPTION
# Overview

Context: https://discord.com/channels/1138230179878154300/1420342695544487957/1420342695544487957

The current example for `WatchedQuery.updateSetttings` is using an incorrect syntax. The `query` parameter needs to be an instance of `WatchCompatibleQuery` (not a direct object containing `sql` and `parameters`). See example unit [test](https://github.com/powersync-ja/powersync-js/blob/c9c1e246bfd67134a7b816c91e482c895db716bb/packages/web/tests/watch.test.ts#L757).

This updates the example.