### PR TITLE
Update sync stream parameter docs

### DIFF
--- a/usage/sync-streams.mdx
+++ b/usage/sync-streams.mdx
@@ -155,7 +155,13 @@ Under the hood, Sync Streams use the same bucket system as Sync Rules, so you ge
 
 ### Accessing Parameters
 
-We have streamlined how different kinds of parameters are accessed in Sync Streams [compared](/usage/sync-rules/parameter-queries) to Sync Rules:
+We have streamlined how different kinds of parameters are accessed in Sync Streams [compared](/usage/sync-rules/parameter-queries) to Sync Rules.
+
+Both auth parameters (extracted from the JWT) and connection parameters (also called [client parameters](/usage/sync-rules/advanced-topics/client-parameters) in sync rules)
+can be queried with the `.parameter('name')` function to extract a single one or with `.parameters()` to get all of them
+as a JSON object.
+Additionally, sync streams support per-stream parameters (and clients can subscribe to the same stream multiple times with
+different parameters):
 
 **Subscription Parameters**: Passed from the client when it subscribes to a Sync Stream:
 
@@ -166,8 +172,8 @@ subscription.parameter('key') # shorthand for getting a specific parameter
 
 **Auth Parameters**: Claims from the JWT:
 
-```
-auth.jwt() # JWT token payload, as JSON
+```yaml
+auth.parameters() # JWT token payload, as JSON
 auth.parameter('key') # short-hand for getting a specific token payload parameter
 auth.user_id() # same as auth.parameter('sub')
 ```
@@ -175,7 +181,7 @@ auth.user_id() # same as auth.parameter('sub')
 
 **Connection Parameters**: Specified "globally" on the connection level. These are the equivalent of Client Parameters in Sync Rules:
 
-```
+```yaml
 connection.parameters() # all parameters for the connection, as JSON
 connection.parameter('key') # shorthand for getting a specific connection parameter
 ```


### PR DESCRIPTION
The docs currently mention `auth.jwt()` which isn't a thing (we consistently use `.parameters()` to get all parameters). This updates the snippet and adds a paragraph explaining the kinds of parameters available in sync streams.