### PR TITLE
Favor 'listen' rather than 'subscribe' for watched queries

### DIFF
--- a/client-sdk-references/dotnet.mdx
+++ b/client-sdk-references/dotnet.mdx
@@ -47,7 +47,7 @@ For more details, please refer to the package [README](https://github.com/powers
 
 * Provides real-time streaming of database changes.
 * Offers direct access to the SQLite database, enabling the use of SQL on both client and server sides.
-* Enables subscription to queries for receiving live updates.
+* Provides watched queries that allow listening for live updates to data.
 * Eliminates the need for client-side database migrations as these are managed automatically.
 
 ## Quickstart

--- a/client-sdk-references/flutter/usage-examples.mdx
+++ b/client-sdk-references/flutter/usage-examples.mdx
@@ -24,7 +24,7 @@ deleteList(SqliteDatabase db, String id) async {
 
 Also see [readTransaction(callback)](https://pub.dev/documentation/powersync/latest/sqlite_async/SqliteQueries/readTransaction.html) .
 
-## Subscribe to changes in data
+## Listen for changes in data
 
 Use [watch](https://pub.dev/documentation/powersync/latest/sqlite_async/SqliteQueries/watch.html) to watch for changes to the dependent tables of any SQL query.
 

--- a/client-sdk-references/javascript-web/usage-examples.mdx
+++ b/client-sdk-references/javascript-web/usage-examples.mdx
@@ -107,7 +107,7 @@ export const ListsWidget = () => {
 
 Also see [PowerSyncDatabase.readTransaction(callback)](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#readtransaction).
 
-## Subscribe to changes in data
+## Listen for changes in data
 
 Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#watch) to watch for changes in source tables.
 

--- a/client-sdk-references/kotlin-multiplatform/usage-examples.mdx
+++ b/client-sdk-references/kotlin-multiplatform/usage-examples.mdx
@@ -22,7 +22,7 @@ database.writeTransaction {
 }
 ```
 
-## Subscribe to changes in data
+## Listen for changes in data
 
 Use the `watch` method to watch for changes to the dependent tables of any SQL query.
 

--- a/client-sdk-references/react-native-and-expo/usage-examples.mdx
+++ b/client-sdk-references/react-native-and-expo/usage-examples.mdx
@@ -82,7 +82,7 @@ export const ListsWidget = () => {
 
 Also see [PowerSyncDatabase.readTransaction(callback)](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#readtransaction).
 
-## Subscribe to changes in data
+## Listen for changes in data
 
 Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#watch) to watch for changes in source tables.
 

--- a/client-sdk-references/swift/usage-examples.mdx
+++ b/client-sdk-references/swift/usage-examples.mdx
@@ -21,7 +21,7 @@ func deleteList(db: PowerSyncDatabase, listId: String) async throws {
 
 Also see [`readTransaction`](https://powersync-ja.github.io/powersync-swift/documentation/powersync/queries/readtransaction(callback:)).
 
-## Subscribe to changes in data
+## Listen for changes in data
 
 Use `watch` to watch for changes to the dependent tables of any SQL query.
 

--- a/integration-guides/supabase-+-powersync/realtime-streaming.mdx
+++ b/integration-guides/supabase-+-powersync/realtime-streaming.mdx
@@ -2,7 +2,7 @@
 title: "Real-time Streaming"
 ---
 
-If your app uses Supabase Realtime to subscribe to database changes (via e.g. [Stream](https://supabase.com/docs/reference/dart/stream) in the Supabase Flutter client library), it's fairly simple to obtain the same behavior using PowerSync.
+If your app uses Supabase Realtime to listen for database changes (via e.g. [Stream](https://supabase.com/docs/reference/dart/stream) in the Supabase Flutter client library), it's fairly simple to obtain the same behavior using PowerSync.
 
 Postgres changes are constantly streamed to the [PowerSync Service](/architecture/powersync-service) via the logical replication publication.
 

--- a/usage/use-case-examples/watch-queries.mdx
+++ b/usage/use-case-examples/watch-queries.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Live Queries / Watch Queries'
 sidebarTitle: 'Live Queries'
-description: 'Subscribe to real-time data changes with reactive watch queries'
+description: 'Listen to real-time data changes with reactive watch queries'
 ---
 
 import JavaScriptAsyncWatch from '/snippets/basic-watch-query-javascript-async.mdx';
@@ -11,15 +11,15 @@ import KotlinWatch from '/snippets/kotlin-multiplatform/basic-watch-query.mdx';
 import SwiftWatch from '/snippets/swift/basic-watch-query.mdx';
 import DotNetWatch from '/snippets/dotnet/basic-watch-query.mdx';
 
-Watch queries, also known as live queries, are essential for building reactive apps where the UI automatically updates when the underlying data changes. PowerSync's watch functionality allows you to subscribe to SQL query results and receive updates whenever the dependent tables are modified.
+Watch queries, also known as live queries, are essential for building reactive apps where the UI automatically updates when the underlying data changes. PowerSync's watch functionality allows you to listen for SQL query result changes and receive updates whenever the dependent tables are modified.
 
 # Overview
 
 PowerSync provides multiple approaches to watching queries, each designed for different use cases and performance requirements:
 
-1. **Basic Watch Queries** - These queries work across all SDKs, providing real-time updates when dependent tables change
-2. **Incremental Watch Queries** - Only emit updates when data actually changes, preventing unnecessary re-renders
-3. **Differential Watch Queries** - Provide detailed information about what specifically changed between result sets
+1. **Basic Watch Queries** - These queries work across all SDKs, providing real-time updates when dependent tables change.
+2. **Incremental Watch Queries** - Only emit updates when data actually changes, preventing unnecessary re-renders. Available in JavaScript SDKs only.
+3. **Differential Watch Queries** - Provide detailed information about what specifically changed between result sets. Available in JavaScript SDKs only.
 
 Choose the approach that best fits your platform and performance needs.
 
@@ -36,7 +36,7 @@ Scroll horizontally to find your preferred platform/framework for an example:
   This method is only being maintained for backwards compatibility purposes. Use the improved `db.query.watch()` API instead (see [Incremental Watch Queries](#incremental-watch-queries) below).
 </Warning>
 
-The original watch method using the AsyncIterator pattern. This is the foundational watch API that works across all JavaScript environments and is being maintained for backwards compatibility.
+The original watch method using the `AsyncIterator` pattern. This is the foundational watch API that works across all JavaScript environments and is being maintained for backwards compatibility.
 
 <JavaScriptAsyncWatch />
 
@@ -47,7 +47,7 @@ The original watch method using the AsyncIterator pattern. This is the foundatio
   This method is only being maintained for backwards compatibility purposes. Use the improved `db.query.watch()` API instead (see [Incremental Watch Queries](#incremental-watch-queries) below).
 </Warning>
 
-The callback-based watch method that doesn't require AsyncIterator polyfills. Use this approach when you need smoother React Native compatibility or prefer synchronous method signatures:
+The callback-based watch method that doesn't require `AsyncIterator` polyfills. Use this approach when you need smoother React Native compatibility or prefer synchronous method signatures:
 
 <JavaScriptCallbackWatch />
 
@@ -123,7 +123,7 @@ Use this method to watch for changes to the dependent tables of any SQL query:
 
 Basic watch queries can cause performance issues in UI frameworks like React because they return new data on every dependent table change, even when the actual data in the query hasn't changed. This can lead to excessive re-renders as components receive updates unnecessarily.
 
-Incremental watch queries solve this by comparing result sets using configurable comparators and only emitting updates when the comparison detects actual data changes. These queries still query the SQLite DB under the hood on each dependent table change, but compare the result sets and only yield results if a change has been made.
+Incremental watch queries solve this by comparing result sets using configurable comparators and only emitting updates when the comparison detects actual data changes. These queries still query the SQLite database under the hood on each dependent table change, but compare the result sets and only yield results if a change has been made.
 
 <Note>
   **JavaScript Only**: Incremental and differential watch queries are currently only available in the JavaScript SDKs starting from:
@@ -199,7 +199,7 @@ const pendingLists = db
 </Tab>
 <Tab title="React useQuery">
 
-React hook that that preserves object references for unchanged items and uses row-level comparators to minimize re-renders. Use this when you want built-in state management plus incremental updates for React components:
+React hook that preserves object references for unchanged items and uses row-level comparators to minimize re-renders. Use this when you want built-in state management plus incremental updates for React components:
 
 ```javascript
 const {
@@ -259,7 +259,7 @@ const TodoWidget = React.memo(({ record }) => {
 
 <Tab title="Existing AsyncIterator Approach">
 
-Existing AsyncIterator API with configurable comparator that compares current and previous result sets, only yielding when the comparator detects changes. Use this if you want to maintain the familiar AsyncIterator pattern from the basic watch query API:
+Existing `AsyncIterator` API with configurable comparator that compares current and previous result sets, only yielding when the comparator detects changes. Use this if you want to maintain the familiar `AsyncIterator` pattern from the basic watch query API:
 
 ```javascript
 async function* pendingLists(): AsyncIterable<string[]> {
@@ -307,7 +307,7 @@ const pendingLists = (onResult: (lists: any[]) => void): void => {
 
 # Differential Watch Queries
 
-Differential queries go a step further than incremental watched queries by computing and reporting diffs between result sets (added/removed/updated items) while preserving object references for unchanged items. This enables more precise UI updates.
+Differential watch queries go a step further than incremental watched queries by computing and reporting diffs between result sets (added/removed/updated items) while preserving object references for unchanged items. This enables more precise UI updates.
 
 <Note>
   **JavaScript Only**: Incremental and differential watch queries are currently only available in the JavaScript SDKs starting from:
@@ -422,10 +422,10 @@ const dispose2 = sharedListsQuery.registerListener({
 
 ## Dynamic Parameter Updates
 
-Update query parameters to affect all subscribers of the query:
+Update query parameters to affect all listeners of the query:
 
 ```javascript
-// Updates to query parameters can be performed in a single place, affecting all subscribers
+// Updates to query parameters can be performed in a single place, affecting all listeners
 sharedListsQuery.updateSettings({
   query: new GetAllQuery({ sql: 'SELECT * FROM lists WHERE state = ?', parameters: ['canceled'] })
 });
@@ -433,7 +433,7 @@ sharedListsQuery.updateSettings({
 
 ## React Hook for External WatchedQuery Instances
 
-When you need to share query instances across components or manage their lifecycle independently from component mounting, use the `useWatchedQuerySubscription` hook. This is ideal for global state management, query caching, or when multiple components need to subscribe to the same data:
+When you need to share query instances across components or manage their lifecycle independently from component mounting, use the `useWatchedQuerySubscription` hook. This is ideal for global state management, query caching, or when multiple components need to listen to the same data:
 
 ```javascript
 // Managing the WatchedQuery externally can extend its lifecycle and allow in-memory caching between components.


### PR DESCRIPTION
This is something that @kobiebotha and I discussed a while back: 

The terminology "subscription"/"subscribe" is central to Sync Streams, so we want to avoid using "subscription"/"subscribe" w.r.t watched queries to avoid any potential confusion between the two.