### PR TITLE
Fix drizzle transaction snippets

### DIFF
--- a/client-sdks/orms/js/drizzle.mdx
+++ b/client-sdks/orms/js/drizzle.mdx
@@ -270,8 +270,8 @@ For watched queries with Drizzle it's recommended to use the `watch()` function 
 <CodeGroup>
   ```js Drizzle
   await db.transaction(async (transaction) => {
-    await db.insert(users).values({ id: "4", name: "James" });
-    await db
+    await transaction.insert(users).values({ id: "4", name: "James" });
+    await transaction
       .update(users)
       .set({ name: "Lucy James Smith" })
       .where(eq(users.name, "James"));
@@ -283,7 +283,7 @@ For watched queries with Drizzle it's recommended to use the `watch()` function 
   ```
 
   ```js PowerSync
-  await powerSyncDb.writeTransaction((transaction) => {
+  await powerSyncDb.writeTransaction(async (transaction) => {
     await transaction.execute('INSERT INTO users (id, name) VALUES(4, ?)', ['James']);
     await transaction.execute("UPDATE users SET name = ? WHERE name = ?", ['James Smith', 'James']);
   })


### PR DESCRIPTION
We should use the transaction handle in the callback to avoid deadlocks, and the PowerSync transaction callback should be asynchronous.

Closes #388.