### PR TITLE
Update docs for upcoming Dart release

### DIFF
--- a/client-sdks/advanced/data-encryption.mdx
+++ b/client-sdks/advanced/data-encryption.mdx
@@ -11,14 +11,44 @@ Data is always encrypted in transit using TLS — both between the client and Po
 The client-side database can be encrypted at rest. This is currently available for:
 
 <Accordion title="Dart/Flutter" icon="flutter">
-[SQLCipher](https://www.zetetic.net/sqlcipher/) support is available for Dart/Flutter through the `powersync_sqlcipher` SDK. See usage details in the package README:
 
-<Card
-  title="powersync_sqlcipher"
-  icon="flutter"
-  href="https://pub.dev/packages/powersync_sqlcipher"
-  horizontal
-/>
+The PowerSync SDK supports [SQLite3MultipleCiphers](https://utelle.github.io/SQLite3MultipleCiphers)
+on all native platforms and the web, which can be used to encrypt databases.
+
+<Note>Setting up encryption has changed in version 2.0 of the PowerSync SDK. When upgrading, follow these steps and remove dependencies on `powersync_sqlcipher`.</Note>
+
+To enable encryption, pass an instance of `EncryptionOptions` to a `PowerSyncDatabase` constructor:
+
+```dart
+final db = PowerSyncDatabase(
+  schema: schema,
+  path: path,
+  encryption: EncryptionOptions(
+    key: 'my secret key',
+  ),
+);
+```
+
+Additionally, encryption needs to be enabled for your target platforms.
+For native platforms, add this snippet to your `pubspec.yaml`:
+
+```yaml
+hooks:
+  user_defines:
+    sqlite3:
+      # Bundle and load SQLite3MultipleCiphers instead of SQLite for encryption.
+      source: sqlite3mc
+```
+
+<Warning>If you're using [pub workspaces](https://dart.dev/tools/pub/workspaces), this needs to be added to the root `pubspec.yaml`, not the one for your app.</Warning>
+
+On the web, enabling encryption requires SQLite3MultipleCiphers as well. [PowerSync releases](https://github.com/powersync-ja/powersync.dart/releases)
+have a `sqlite3mc.wasm` file attached to them, which can be downloaded to `web/sqlite3.wasm` to add encryption
+support.
+
+You can also run `dart run powersync:setup_web --encryption` to download the correct binary into your `web/`
+directory.
+
 </Accordion>
 
 <Accordion title="React Native & Expo" icon="react">

--- a/client-sdks/frameworks/flutter-web-support.mdx
+++ b/client-sdks/frameworks/flutter-web-support.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Web Support"
 ---
 
 <Note>
-Web support for Flutter in version `^1.9.0` is currently in a **beta** release. It is functionally ready for production use, provided that you've tested your use cases. 
+Since version 1.9.0, web support for Flutter is in a **beta** release. It is functionally ready for production use, provided that you've tested your use cases.
 
 Please see the [Limitations](#limitations) detailed below.
 </Note>
@@ -15,7 +15,7 @@ The easiest way to test Flutter Web support is to run the [Supabase Todo-List](h
 
 1. Clone the [powersync.dart](https://github.com/powersync-ja/powersync.dart/tree/main) repo.
    1. **Note**: If you are an existing user updating to the latest code after a git pull, run `melos exec 'flutter pub upgrade'` in the repo's root and make sure it succeeds.
-2. Run `melos prepare` in the repo's root
+2. Run `dart pub get` and `melos run prepare` in the repo's root
 3. cd into the `demos/supabase-todolist` folder
 4. If you haven’t yet: `cp lib/app_config_template.dart lib/app_config.dart` (optionally update this config with your own Supabase and PowerSync project details).
 5. Run `flutter run -d chrome`
@@ -25,7 +25,7 @@ The easiest way to test Flutter Web support is to run the [Supabase Todo-List](h
 Install the [latest version](https://pub.dev/packages/powersync/versions) of the package, for example:
 
 ```bash
-flutter pub add powersync:'^1.9.0'
+dart pub add powersync:'^2.0.0'
 ```
 
 ### Additional config
@@ -48,7 +48,7 @@ This SDK supports different storage modes of the SQLite database with varying le
 
 OPFS is the preferred mode when it is available. Otherwise database storage falls back to IndexedDB.
 
-Enabling OPFS requires adding two headers to the HTTP server response when a client requests the Flutter web application:
+OPFS is used by default on Firefox and Chrome. For Safari, enabling OPFS requires adding two headers to the HTTP server response when a client requests the Flutter web application:
 
 - `Cross-Origin-Opener-Policy`: Needs to be set to `same-origin`.
 - `Cross-Origin-Embedder-Policy`: Needs to be set to `require-corp`.
@@ -78,13 +78,15 @@ Flutter Web does not support importing directly from `sqlite3.dart` as it uses `
 Change imports from:
 
 ```dart
-import 'package/powersync/sqlite3.dart`
+import 'package:powersync/sqlite3.dart`;
+// or
+import 'package:sqlite3/sqlite3.dart`;
 ```
 
 to:
 
 ```dart
-import 'package/powersync/sqlite3_common.dart'
+import 'package:sqlite3/sqlite3_common.dart';
 ```
 
 in code which needs to run on the Web platform. Isolated native-specific code can still import from `sqlite3.dart`.

--- a/client-sdks/reference/flutter.mdx
+++ b/client-sdks/reference/flutter.mdx
@@ -119,10 +119,13 @@ To instantiate `PowerSyncDatabase`, inject the Schema you defined in the previou
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:powersync/powersync.dart';
-import '../main.dart';
 import '../models/schema.dart';
 
-openDatabase() async {
+// TODO: Use riverpod, providers or another state management
+// approach instead of a global variable to store the database.
+late PowerSyncDatabase db;
+
+Future<void> openDatabase() async {
   final dir = await getApplicationSupportDirectory();
   final path = join(dir.path, 'powersync-dart.db');
 
@@ -137,13 +140,11 @@ Once you've instantiated your PowerSync database, call the [connect()](https://p
 
 <LocalOnly />
 
-```dart lib/main.dart {35}
+```dart lib/main.dart {26}
 import 'package:flutter/material.dart';
 import 'package:powersync/powersync.dart';
 
 import 'powersync/powersync.dart';
-
-late PowerSyncDatabase db;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -161,22 +162,18 @@ class DemoApp extends StatefulWidget {
 
 class _DemoAppState extends State<DemoApp> {
   @override
+  void initState() {
+    super.initState();
+
+    // TODO: Observe a condition to connect / disconnect.
+    db.connect(connector: MyBackendConnector());
+  }
+
+  @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        title: 'Demo',
-        home: // TODO: Implement your own UI here.
-        // You could listen for authentication state changes to connect or disconnect from PowerSync
-        StreamBuilder(
-            stream: // TODO: some stream,
-            builder: (ctx, snapshot) {,
-              // TODO: implement your own condition here
-              if ( ... ) {
-                // Uses the backend connector that will be created in the next step
-                db.connect(connector: MyBackendConnector());
-                // TODO: implement your own UI here
-              }
-            },
-        )
+      title: 'Demo',
+      // TODO: Implement your own UI here.
     );
   }
 }
@@ -376,5 +373,5 @@ See [Supported Platforms -> Dart SDK](/resources/supported-platforms#dart-sdk).
 To upgrade to a newer version of the PowerSync package, run the below command in your project folder:
 
 ```bash
-flutter pub upgrade powersync
+dart pub upgrade powersync
 ```

--- a/resources/supported-platforms.mdx
+++ b/resources/supported-platforms.mdx
@@ -5,13 +5,10 @@ description: "Supported platforms and major features by PowerSync Client SDK"
 
 ## <Icon icon="flutter" iconType="solid" size={32}/> Dart/Flutter SDK
 
-Starting from version 2.0 of the PowerSync Dart SDK, all native targets are supported
-without Flutter as well.
-
 | Platform / Feature | Supported? | Notes |
 | --- | --- | --- |
-| Android | Yes (x86-64, aarch64, armv7) |  |
-| iOS | Yes | |
+| Android | Yes (x86-64, aarch64, armv7) | Requires Flutter |
+| iOS | Yes | Requires Flutter |
 | macOS | Yes (x86-64, aarch64) | |
 | Windows | Yes (x86-64, x86, aarch64) | |
 | Linux | Yes (x86-64, x86, aarch64, armv7, riscv64gc) | |

--- a/resources/supported-platforms.mdx
+++ b/resources/supported-platforms.mdx
@@ -5,18 +5,17 @@ description: "Supported platforms and major features by PowerSync Client SDK"
 
 ## <Icon icon="flutter" iconType="solid" size={32}/> Dart/Flutter SDK
 
+Starting from version 2.0 of the PowerSync Dart SDK, all native targets are supported
+without Flutter as well.
+
 | Platform / Feature | Supported? | Notes |
 | --- | --- | --- |
-| Flutter Android | Yes (x86-64, aarch64, armv7) | |
-| Flutter iOS | Yes | |
-| Flutter macOS | Yes (x86-64, aarch64) | |
-| Flutter Windows | Yes (x86-64 only) | |
-| Flutter Linux | Yes (x86-64, aarch64) | |
-| Flutter web | Yes | Only dart2js is tested, dart2wasm has issues |
-| Dart web | With custom setup | |
-| Dart macOS | With custom setup | |
-| Dart Windows | With custom setup (x86-64 only) | |
-| Dart Linux | With custom setup (x86-64, aarch64) | Dart supports armv7 and riscv64gc as well, we currently don't |
+| Android | Yes (x86-64, aarch64, armv7) |  |
+| iOS | Yes | |
+| macOS | Yes (x86-64, aarch64) | |
+| Windows | Yes (x86-64, x86, aarch64) | |
+| Linux | Yes (x86-64, x86, aarch64, armv7, riscv64gc) | |
+| Web | Yes | Only dart2js is tested, dart2wasm has issues |
 | HTTP connection method | Yes | |
 | WebSocket connection method | No | |
 

--- a/snippets/flutter/installation.mdx
+++ b/snippets/flutter/installation.mdx
@@ -1,5 +1,5 @@
 Add the [PowerSync pub.dev package](https://pub.dev/packages/powersync) to your project:
 
 ```bash
-flutter pub add powersync
+dart pub add powersync
 ```


### PR DESCRIPTION
This updates documentation to reflect pending changes for the Dart SDK:

- Configuring encryption is part of the regular `powersync` package now, but requires a few more steps. 
- We support many more Desktop ABIs, and we support them even without Flutter.
- Due to a `sqlite3_web` upgrade, we support OPFS on Chrome without extra headers.
- This replaces a few `flutter pub` commands with `dart pub` (Flutter ships with a Dart SDK so these commands will work for everyone).

Finally, this replaces a sketchy "connect in streambuilder" pattern with `initState`, a better place to run effects.