### PR TITLE
Add Room encryption docs for Kotlin SDK

### DIFF
--- a/client-sdks/advanced/data-encryption.mdx
+++ b/client-sdks/advanced/data-encryption.mdx
@@ -130,35 +130,7 @@ val database = PowerSyncDatabase(
 
 For more details, see the [`sqlite3multipleciphers` README](https://github.com/powersync-ja/powersync-kotlin/tree/main/sqlite3multipleciphers) in the PowerSync Kotlin SDK repository.
 
-**Using encryption with Room:**
-
-When using PowerSync [with Room](/client-sdks/orms/kotlin/room), PowerSync wraps the Room database instead of opening its own connection. To use an encrypted database with Room, wrap an encrypted `PersistentConnectionFactory` in a `SQLiteDriver` and pass it to `RoomDatabase.Builder.setDriver`:
-
-```kotlin
-class PowerSyncConnectionFactoryAsSqliteDriver(
-    private val powersyncFactory: PersistentConnectionFactory
-) : SQLiteDriver {
-    override fun open(fileName: String): SQLiteConnection {
-        if (fileName == ":memory:") {
-            return powersyncFactory.openInMemoryConnection()
-        }
-
-        return powersyncFactory.openConnection(fileName, null, false)
-    }
-}
-```
-
-Depending on your target platform, pass an `AndroidEncryptedDatabaseFactory`, `JavaEncryptedDatabaseFactory`, or `NativeEncryptedDatabaseFactory` to the wrapper. The factory automatically installs the PowerSync SQLite extension, so you can skip the `loadPowerSyncExtension()` step.
-
-```kotlin
-val driver = PowerSyncConnectionFactoryAsSqliteDriver(
-    AndroidEncryptedDatabaseFactory(context, Key.Passphrase("your encryption key"))
-)
-
-val roomDb = Room.databaseBuilder<MyDatabase>(context, "your_database")
-    .setDriver(driver)
-    .build()
-```
+If you're using PowerSync with Room, see the [Room encrypted databases section](/client-sdks/orms/kotlin/room#encrypted-databases) for the recommended setup.
 </Accordion>
 
 <Accordion title="Swift" icon="swift">

--- a/client-sdks/advanced/data-encryption.mdx
+++ b/client-sdks/advanced/data-encryption.mdx
@@ -129,6 +129,36 @@ val database = PowerSyncDatabase(
 </Note>
 
 For more details, see the [`sqlite3multipleciphers` README](https://github.com/powersync-ja/powersync-kotlin/tree/main/sqlite3multipleciphers) in the PowerSync Kotlin SDK repository.
+
+**Using encryption with Room:**
+
+When using PowerSync [with Room](/client-sdks/orms/kotlin/room), PowerSync wraps the Room database instead of opening its own connection. To use an encrypted database with Room, wrap an encrypted `PersistentConnectionFactory` in a `SQLiteDriver` and pass it to `RoomDatabase.Builder.setDriver`:
+
+```kotlin
+class PowerSyncConnectionFactoryAsSqliteDriver(
+    private val powersyncFactory: PersistentConnectionFactory
+) : SQLiteDriver {
+    override fun open(fileName: String): SQLiteConnection {
+        if (fileName == ":memory:") {
+            return powersyncFactory.openInMemoryConnection()
+        }
+
+        return powersyncFactory.openConnection(fileName, null, false)
+    }
+}
+```
+
+Depending on your target platform, pass an `AndroidEncryptedDatabaseFactory`, `JavaEncryptedDatabaseFactory`, or `NativeEncryptedDatabaseFactory` to the wrapper. The factory automatically installs the SQLite3MultipleCiphers extension — no manual setup required.
+
+```kotlin
+val driver = PowerSyncConnectionFactoryAsSqliteDriver(
+    AndroidEncryptedDatabaseFactory(context, Key.Passphrase("your encryption key"))
+)
+
+val roomDb = Room.databaseBuilder<MyDatabase>(context, "your_database")
+    .setDriver(driver)
+    .build()
+```
 </Accordion>
 
 <Accordion title="Swift" icon="swift">

--- a/client-sdks/advanced/data-encryption.mdx
+++ b/client-sdks/advanced/data-encryption.mdx
@@ -148,7 +148,7 @@ class PowerSyncConnectionFactoryAsSqliteDriver(
 }
 ```
 
-Depending on your target platform, pass an `AndroidEncryptedDatabaseFactory`, `JavaEncryptedDatabaseFactory`, or `NativeEncryptedDatabaseFactory` to the wrapper. The factory automatically installs the SQLite3MultipleCiphers extension — no manual setup required.
+Depending on your target platform, pass an `AndroidEncryptedDatabaseFactory`, `JavaEncryptedDatabaseFactory`, or `NativeEncryptedDatabaseFactory` to the wrapper. The factory automatically installs the PowerSync SQLite extension, so you can skip the `loadPowerSyncExtension()` step.
 
 ```kotlin
 val driver = PowerSyncConnectionFactoryAsSqliteDriver(

--- a/client-sdks/orms/kotlin/room.mdx
+++ b/client-sdks/orms/kotlin/room.mdx
@@ -50,7 +50,7 @@ To add PowerSync to your Room database,
 
 ## Encrypted databases
 
-When using PowerSync with Room, PowerSync wraps the Room database instead of opening its own connection. To use an encrypted database with Room, wrap an encrypted `PersistentConnectionFactory` in a `SQLiteDriver` and pass it to `RoomDatabase.Builder.setDriver`:
+When using PowerSync with Room, PowerSync wraps the Room database instead of opening its own connection. To use an encrypted database with Room, implement `SQLiteDriver` by delegating to `PersistentConnectionFactory` and pass that to `RoomDatabase.Builder.setDriver`:
 
 ```kotlin
 class PowerSyncConnectionFactoryAsSqliteDriver(

--- a/client-sdks/orms/kotlin/room.mdx
+++ b/client-sdks/orms/kotlin/room.mdx
@@ -48,6 +48,36 @@ To add PowerSync to your Room database,
     Room.databaseBuilder(...).setDriver(driver).build()
     ```
 
+## Encrypted databases
+
+When using PowerSync with Room, PowerSync wraps the Room database instead of opening its own connection. To use an encrypted database with Room, wrap an encrypted `PersistentConnectionFactory` in a `SQLiteDriver` and pass it to `RoomDatabase.Builder.setDriver`:
+
+```kotlin
+class PowerSyncConnectionFactoryAsSqliteDriver(
+    private val powersyncFactory: PersistentConnectionFactory
+) : SQLiteDriver {
+    override fun open(fileName: String): SQLiteConnection {
+        if (fileName == ":memory:") {
+            return powersyncFactory.openInMemoryConnection()
+        }
+
+        return powersyncFactory.openConnection(fileName, null, false)
+    }
+}
+```
+
+Depending on your target platform, pass an `AndroidEncryptedDatabaseFactory`, `JavaEncryptedDatabaseFactory`, or `NativeEncryptedDatabaseFactory` to the wrapper. The factory automatically installs the PowerSync SQLite extension, so you can skip the `loadPowerSyncExtension()` step.
+
+```kotlin
+val driver = PowerSyncConnectionFactoryAsSqliteDriver(
+    AndroidEncryptedDatabaseFactory(context, Key.Passphrase("your encryption key"))
+)
+
+val roomDb = Room.databaseBuilder<MyDatabase>(context, "your_database")
+    .setDriver(driver)
+    .build()
+```
+
 ## Setup
 
 Because PowerSync syncs into tables that you've created with Room, it needs to know which SQL statements to run for


### PR DESCRIPTION
### Changes                                                                                                                                                                         
  - `data-encryption.mdx`: Added instructions for using encryption with Room in the Kotlin section. Uses `PowerSyncConnectionFactoryAsSqliteDriver` to wrap an encrypted               
  `PersistentConnectionFactory` and pass it to `RoomDatabase.Builder.setDriver`.
  - ~~Added pnpm setup with mintlify as a dev dependency.~~                                                                                             
  - ~~README.md: Updated Quick Start to use pnpm install + npm run dev instead of npx mintlify commands.~~ See #406 

The last two points are just for easier use. We can now simply do `pnpm dev` to spin the docs
