### PR TITLE
Use max-old-space-size-percentage=80 in NODE_OPTIONS guidance

### DIFF
--- a/maintenance-ops/self-hosting/deployment-architecture.mdx
+++ b/maintenance-ops/self-hosting/deployment-architecture.mdx
@@ -39,7 +39,7 @@ If you use rolling deploys, it is normal to see this error for a short duration 
 
 Memory and CPU usage of the replication container is primarily driven by write load on the source database. A good starting point is 1GB memory and 1 vCPU for the container, but this may be scaled down depending on the load patterns.
 
-Set the environment variable `NODE_OPTIONS=--max-old-space-size=800` for 800MB, or set to 80% of the total assigned memory if scaling up or down.
+Set the environment variable `NODE_OPTIONS=--max-old-space-size-percentage=80` to allocate 80% of the container's assigned memory to the Node.js heap. This avoids manually retuning when scaling resources up or down.
 
 ### API Containers
 
@@ -56,7 +56,7 @@ Memory and CPU usage of API containers are driven by:
 
 A good starting point is 1GB memory and 1 vCPU per container, but this may be scaled up or down depending on the specific load patterns.
 
-Set the environment variable `NODE_OPTIONS=--max-old-space-size=800` for 800MB, or set to 80% of the total assigned memory if scaling up or down.
+Set the environment variable `NODE_OPTIONS=--max-old-space-size-percentage=80` to allocate 80% of the container's assigned memory to the Node.js heap. This avoids manually retuning when scaling resources up or down.
 
 ### Compact Job
 
@@ -64,7 +64,7 @@ We recommend running a compact job daily as a cron job, or after any large maint
 
 Run the compact job using the docker command `compact`, for example `docker run powersync compact`.
 
-The compact job uses up to 1GB memory for compacting, if available. Set the environment variable `NODE_OPTIONS=--max-old-space-size=800` for 800MB, or set to 80% of the total assigned memory if scaling up or down.
+The compact job uses up to 1GB memory for compacting, if available. Set the environment variable `NODE_OPTIONS=--max-old-space-size-percentage=80` to allocate 80% of the container's assigned memory to the Node.js heap. This avoids manually retuning when scaling resources up or down.
 
 ### Load Balancer
 


### PR DESCRIPTION
Updates the `NODE_OPTIONS` recommendation in the self-hosting deployment architecture docs from the manually-tuned `--max-old-space-size=800` to `--max-old-space-size-percentage=80`. Operators no longer need to retune the heap whenever container memory changes.

This matches the guidance already adopted in `maintenance-ops/self-hosting/aws-ecs.mdx` (PR #347), discussed [in this comment](https://github.com/powersync-ja/powersync-docs/pull/347#discussion_r2782892624).