### PR TITLE
Diagnosing sync latency

### DIFF
--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -396,18 +396,16 @@ This covers the whole pipeline in one number, but does not tell you which stage 
 
 #### Stage 1: Source Database to PowerSync Service
 
-Check the **replication lag** metric on the PowerSync Dashboard's **Metrics** view. This shows whether replication from your source database is keeping up.
+Check the **Replication Lag** chart in the **Metrics** view of the [PowerSync Dashboard](https://dashboard.powersync.com/). This shows whether replication from your source database is keeping up. Replicator logs in the **Logs** view surface any replication errors that would cause delays at this stage.
 
-For Postgres sources, you can also query the replication slots directly to see the current WAL backlog. See [Logical Replication Slots](/configuration/source-db/postgres-maintenance#logical-replication-slots) for the query and guidance on interpreting the result.
-
-Replicator logs in the **Logs** view of the [PowerSync Dashboard](https://dashboard.powersync.com/) surface any replication errors that would cause delays at this stage.
+For a deeper walkthrough of what drives replication lag, how to interpret it for your specific source (Postgres, MongoDB, MySQL, SQL Server), and how to reduce it, see [Replication Lag](/maintenance-ops/replication-lag).
 
 #### Stage 2: PowerSync Service to Client
 
 Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record each client sync session. Two events are useful when investigating a specific user's experience:
 
 * **Sync stream started**: logged when a client connects. Includes `user_id`, `client_id`, `app_metadata` (if set), and client parameters.
-* **Sync stream completed**: logged when the session ends. Includes `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (session duration).
+* **Sync stream complete**: logged when the session ends. Includes `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (session duration).
 
 If a user reports "data took several seconds to show up at 2:15 PM", filter the logs by their `user_id` around that time. The matched events show how many operations were synced, how much data was transferred, and how long the connection was active.
 
@@ -419,7 +417,7 @@ A few patterns account for most latency reports:
 
 * **Large initial sync**: if your sync rules result in a large dataset, the first sync after connecting will be slow. Inspect bucket sizes and sync state with the [Sync Diagnostics Client](/tools/diagnostics-client).
 * **Upload queue blocking downloads**: by default, uploads are processed before downloads, so a backlogged upload queue delays receiving new data. Buckets and streams at [priority 0](/sync/advanced/prioritized-sync) are not blocked by uploads, but come with the trade-off of potential sync inconsistencies.
-* **Postgres WAL backlog**: high write volume on the source database can cause the replication slot to fall behind. See [Postgres Maintenance](/configuration/source-db/postgres-maintenance) for managing this.
+* **Replication lag on the source database**: high write volume, long-running transactions, bulk updates, or backfills can cause replication to fall behind faster than the service can drain it. See [Replication Lag](/maintenance-ops/replication-lag) for source-specific causes and fixes.
 * **Too many buckets per user**: incremental sync overhead scales roughly linearly with the number of buckets per user. See [Too Many Buckets](#too-many-buckets-psync_s2305) above.
 
 ### Web: Logging queries on the performance timeline

--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -374,6 +374,54 @@ These are some common pointers when it comes to diagnosing and understanding per
 2. The **initial sync** on a client can take a while in cases where the operations history is large. See [Compacting Buckets](/maintenance-ops/compacting-buckets) to optimize sync performance.
 3. You can get big performance gains by using **transactions & batching** as explained in this [blog post](https://www.powersync.com/blog/flutter-database-comparison-sqlite-async-sqflite-objectbox-isar).
 
+### Diagnosing Sync Latency
+
+When a user reports that a write took too long to reach their device, there is no single end-to-end trace that covers the full path from your source database to the client. Instead, isolate each stage of the pipeline to find the bottleneck.
+
+The pipeline has three stages:
+
+1. **Source database to PowerSync Service** (replication).
+2. **PowerSync Service to client** (sync session).
+3. **End-to-end** (write committed in source database to row visible on the device).
+
+#### Measuring End-to-End Latency
+
+The most reliable way to measure the full round trip is to put a timestamp in the data itself. When a row is written or updated in your source database, set a column to the current server time (e.g. `updated_at = NOW()`). On the client, compare that timestamp to the time the row arrives in the local database. The difference is the total time from the source write to data being visible on the device.
+
+This covers the whole pipeline in one number, but does not tell you which stage is slow. Use the per-stage diagnostics below to break it down.
+
+<Note>
+  [Custom Write Checkpoints](/handling-writes/custom-write-checkpoints) are not a latency measurement tool. They are a per-client consistency mechanism tied to the upload cycle and carry sequence numbers, not timestamps. They tell you whether a client's own upload has been reflected back to it, not how long a backend write took to reach a device.
+</Note>
+
+#### Stage 1: Source Database to PowerSync Service
+
+Check the **replication lag** metric on the PowerSync Dashboard's **Metrics** view. This shows whether replication from your source database is keeping up.
+
+For Postgres sources, you can also query the replication slots directly to see the current WAL backlog. See [Logical Replication Slots](/configuration/source-db/postgres-maintenance#logical-replication-slots) for the query and guidance on interpreting the result.
+
+Replicator logs in the **Logs** view of the [PowerSync Dashboard](https://dashboard.powersync.com/) surface any replication errors that would cause delays at this stage.
+
+#### Stage 2: PowerSync Service to Client
+
+Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record each client sync session. Two events are useful when investigating a specific user's experience:
+
+* **Sync stream started**: logged when a client connects. Includes `user_id`, `client_id`, `app_metadata` (if set), and client parameters.
+* **Sync stream completed**: logged when the session ends. Includes `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (session duration).
+
+If a user reports "data took several seconds to show up at 2:15 PM", filter the logs by their `user_id` around that time. The matched events show how many operations were synced, how much data was transferred, and how long the connection was active.
+
+[Custom metadata](/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) attached at `connect()` time is included in both events, so you can also filter by app version, environment, or other context you set.
+
+#### Common Causes of Latency
+
+A few patterns account for most latency reports:
+
+* **Large initial sync**: if your sync rules result in a large dataset, the first sync after connecting will be slow. Inspect bucket sizes and sync state with the [Sync Diagnostics Client](/tools/diagnostics-client).
+* **Upload queue blocking downloads**: by default, uploads are processed before downloads, so a backlogged upload queue delays receiving new data. Buckets and streams at [priority 0](/sync/advanced/prioritized-sync) are not blocked by uploads, but come with the trade-off of potential sync inconsistencies.
+* **Postgres WAL backlog**: high write volume on the source database can cause the replication slot to fall behind. See [Postgres Maintenance](/configuration/source-db/postgres-maintenance) for managing this.
+* **Too many buckets per user**: incremental sync overhead scales roughly linearly with the number of buckets per user. See [Too Many Buckets](#too-many-buckets-psync_s2305) above.
+
 ### Web: Logging queries on the performance timeline
 
 Enabling the `debugMode` flag in the [Web SDK](/client-sdks/reference/javascript-web) logs all SQL queries on the Performance timeline in Chrome's Developer Tools (after recording). This can help identify slow-running queries.

--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -376,19 +376,22 @@ These are some common pointers when it comes to diagnosing and understanding per
 
 ### Diagnosing Sync Latency
 
-When a user reports that a write took too long to reach their device, there is no single end-to-end trace that covers the full path from your source database to the client. Instead, isolate each stage of the pipeline to find the bottleneck.
+When a user reports that a write took too long to reach their device, there is no single trace that covers the full path. Instead, isolate each stage of the pipeline to find the bottleneck.
 
-The pipeline has three stages:
+The downstream pipeline (source database to client) has two stages:
 
 1. **Source database to PowerSync Service** (replication).
 2. **PowerSync Service to client** (sync session).
-3. **End-to-end** (write committed in source database to row visible on the device).
 
-#### Measuring End-to-End Latency
+A full end-to-end picture also includes the upstream path (client write → your backend API → source database commit), which sits outside PowerSync and is not covered by the diagnostics below.
 
-The most reliable way to measure the full round trip is to put a timestamp in the data itself. When a row is written or updated in your source database, set a column to the current server time (e.g. `updated_at = NOW()`). On the client, compare that timestamp to the time the row arrives in the local database. The difference is the total time from the source write to data being visible on the device.
+#### Measuring Downstream Latency (Source to Device)
 
-This covers the whole pipeline in one number, but does not tell you which stage is slow. Use the per-stage diagnostics below to break it down.
+The most reliable way to measure the downstream pipeline is to put a timestamp in the data itself. When a row is written or updated in your source database, set a column to the current server time (e.g. `updated_at = NOW()`). On the client, compare that timestamp to the time the row arrives in the local database. The difference is the time from the source write being committed to the row being visible on the device.
+
+This does not include the time taken for the client to send a write to your backend, the backend's processing, or the backend's commit to the source database. To measure those, instrument your backend API directly (e.g. log request received and source DB commit timestamps).
+
+This number covers the downstream pipeline as a whole but does not tell you which stage is slow. Use the per-stage diagnostics below to break it down.
 
 #### Stage 1: Source Database to PowerSync Service
 
@@ -399,8 +402,6 @@ For a deeper walkthrough of what drives replication lag, how to interpret it for
 #### Stage 2: PowerSync Service to Client
 
 Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record a **Sync stream started** event when a client connects and a **Sync stream complete** event when the session ends. Together they show how many operations were synced, how much data was transferred, and how long the connection stayed open. See [Correlating User Reports to Sync Sessions](/maintenance-ops/monitoring-and-alerting#correlating-user-reports-to-sync-sessions) for the full list of fields on each event.
-
-If a user reports "data took several seconds to show up at 2:15 PM", filter the logs by their `user_id` around that time to locate the matching session.
 
 [Custom metadata](/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) attached at `connect()` time is included in both events, so you can also filter by app version, environment, or other context you set.
 

--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -376,22 +376,20 @@ These are some common pointers when it comes to diagnosing and understanding per
 
 ### Diagnosing Sync Latency
 
-When a user reports that a write took too long to reach their device, there is no single trace that covers the full path. Instead, isolate each stage of the pipeline to find the bottleneck.
+If writes are slow to reach the client, there is no single trace that covers the full path. Isolate each stage of the pipeline to find the bottleneck.
 
 The downstream pipeline (source database to client) has two stages:
 
 1. **Source database to PowerSync Service** (replication).
 2. **PowerSync Service to client** (sync session).
 
-A full end-to-end picture also includes the upstream path (client write → your backend API → source database commit), which sits outside PowerSync and is not covered by the diagnostics below.
+The upstream path (the client sending a write to your backend, your backend processing it, and your backend committing to the source database) sits outside PowerSync and is not covered by the diagnostics below. To measure that, instrument your backend API directly.
 
 #### Measuring Downstream Latency (Source to Device)
 
-The most reliable way to measure the downstream pipeline is to put a timestamp in the data itself. When a row is written or updated in your source database, set a column to the current server time (e.g. `updated_at = NOW()`). On the client, compare that timestamp to the time the row arrives in the local database. The difference is the time from the source write being committed to the row being visible on the device.
+To measure the downstream pipeline, put a timestamp in the data itself. When a row is written or updated in your source database, set a column to the current server time (e.g. `updated_at = NOW()`). On the client, compare that timestamp to the time the row arrives in the local database. The difference is the time from the source write being committed to the row being visible on the device.
 
-This does not include the time taken for the client to send a write to your backend, the backend's processing, or the backend's commit to the source database. To measure those, instrument your backend API directly (e.g. log request received and source DB commit timestamps).
-
-This number covers the downstream pipeline as a whole but does not tell you which stage is slow. Use the per-stage diagnostics below to break it down.
+This gives you a single number for the downstream pipeline but does not tell you which stage is slow. Use the per-stage diagnostics below to break it down.
 
 #### Stage 1: Source Database to PowerSync Service
 
@@ -401,13 +399,11 @@ For a deeper walkthrough of what drives replication lag, how to interpret it for
 
 #### Stage 2: PowerSync Service to Client
 
-Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record a **Sync stream started** event when a client connects and a **Sync stream complete** event when the session ends. Together they show how many operations were synced, how much data was transferred, and how long the connection stayed open. See [Correlating User Reports to Sync Sessions](/maintenance-ops/monitoring-and-alerting#correlating-user-reports-to-sync-sessions) for the full list of fields on each event.
+Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record a **Sync stream started** event when a client connects and a **Sync stream complete** event when the session ends. The complete event includes how many operations were synced, how much data was transferred, and how long the connection stayed open. See [Correlating Sync Sessions](/maintenance-ops/monitoring-and-alerting#correlating-sync-sessions) for the full list of fields on each event.
 
 [Custom metadata](/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) attached at `connect()` time is included in both events, so you can also filter by app version, environment, or other context you set.
 
 #### Common Causes of Latency
-
-A few patterns account for most latency reports:
 
 * **Large initial sync**: if your sync rules result in a large dataset, the first sync after connecting will be slow. Inspect bucket sizes and sync state with the [Sync Diagnostics Client](/tools/diagnostics-client).
 * **Upload queue blocking downloads**: by default, uploads are processed before downloads, so a backlogged upload queue delays receiving new data. Buckets and streams at [priority 0](/sync/advanced/prioritized-sync) are not blocked by uploads, but come with the trade-off of potential sync inconsistencies.

--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -398,12 +398,9 @@ For a deeper walkthrough of what drives replication lag, how to interpret it for
 
 #### Stage 2: PowerSync Service to Client
 
-Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record each client sync session. Two events are useful when investigating a specific user's experience:
+Service/API logs in the [PowerSync Dashboard](https://dashboard.powersync.com/) record a **Sync stream started** event when a client connects and a **Sync stream complete** event when the session ends. Together they show how many operations were synced, how much data was transferred, and how long the connection stayed open. See [Correlating User Reports to Sync Sessions](/maintenance-ops/monitoring-and-alerting#correlating-user-reports-to-sync-sessions) for the full list of fields on each event.
 
-* **Sync stream started**: logged when a client connects. Includes `user_id`, `client_id`, `app_metadata` (if set), and client parameters.
-* **Sync stream complete**: logged when the session ends. Includes `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (session duration).
-
-If a user reports "data took several seconds to show up at 2:15 PM", filter the logs by their `user_id` around that time. The matched events show how many operations were synced, how much data was transferred, and how long the connection was active.
+If a user reports "data took several seconds to show up at 2:15 PM", filter the logs by their `user_id` around that time to locate the matching session.
 
 [Custom metadata](/maintenance-ops/monitoring-and-alerting#custom-metadata-in-sync-logs) attached at `connect()` time is included in both events, so you can also filter by app version, environment, or other context you set.
 

--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -390,10 +390,6 @@ The most reliable way to measure the full round trip is to put a timestamp in th
 
 This covers the whole pipeline in one number, but does not tell you which stage is slow. Use the per-stage diagnostics below to break it down.
 
-<Note>
-  [Custom Write Checkpoints](/handling-writes/custom-write-checkpoints) are not a latency measurement tool. They are a per-client consistency mechanism tied to the upload cycle and carry sequence numbers, not timestamps. They tell you whether a client's own upload has been reflected back to it, not how long a backend write took to reach a device.
-</Note>
-
 #### Stage 1: Source Database to PowerSync Service
 
 Check the **Replication Lag** chart in the **Metrics** view of the [PowerSync Dashboard](https://dashboard.powersync.com/). This shows whether replication from your source database is keeping up. Replicator logs in the **Logs** view surface any replication errors that would cause delays at this stage.

--- a/maintenance-ops/monitoring-and-alerting.mdx
+++ b/maintenance-ops/monitoring-and-alerting.mdx
@@ -106,6 +106,17 @@ You can manage logs with the following options:
 
 * **Stack Traces**: Option to show or hide stack traces for errors.
 
+### Correlating User Reports to Sync Sessions
+
+When a user reports a sync issue at a specific time, you can find their session in the Service/API logs by filtering on their `user_id`. Two events describe each sync session:
+
+* **Sync stream started**: logged when the client connects. Fields include `user_id`, `client_id`, `app_metadata` (if set), and client parameters.
+* **Sync stream completed**: logged when the session ends. Fields include `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (how long the session lasted).
+
+Together these tell you when a user connected, how much data was synced, and how long the connection stayed open. This is useful for investigating reports like "data took a while to appear at 2:15 PM": locate the matching session and inspect its size and duration.
+
+For diagnosing sync latency end-to-end, see [Diagnosing Sync Latency](/debugging/troubleshooting#diagnosing-sync-latency).
+
 ## Custom Metadata in Sync Logs
 
 Custom metadata in sync logs allows clients to attach additional context to their PowerSync connection for improved observability and analytics. This metadata appears in the Service/API logs, making it easier to track, debug, and analyze sync behavior across your app. For example, you can tag connections with app version, feature flags, or business context.

--- a/maintenance-ops/monitoring-and-alerting.mdx
+++ b/maintenance-ops/monitoring-and-alerting.mdx
@@ -111,7 +111,7 @@ You can manage logs with the following options:
 When a user reports a sync issue at a specific time, you can find their session in the Service/API logs by filtering on their `user_id`. Two events describe each sync session:
 
 * **Sync stream started**: logged when the client connects. Fields include `user_id`, `client_id`, `app_metadata` (if set), and client parameters.
-* **Sync stream completed**: logged when the session ends. Fields include `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (how long the session lasted).
+* **Sync stream complete**: logged when the session ends. Fields include `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (how long the session lasted).
 
 Together these tell you when a user connected, how much data was synced, and how long the connection stayed open. This is useful for investigating reports like "data took a while to appear at 2:15 PM": locate the matching session and inspect its size and duration.
 
@@ -276,7 +276,7 @@ You can specify application metadata when calling `PowerSyncDatabase.connect()`.
 
 ### View Custom Metadata in Logs
 
-Custom metadata appears in the **Service/API logs** section of the [PowerSync Dashboard](https://dashboard.powersync.com/). Navigate to your project and instance, then go to the **Logs** view. The metadata is included in **Sync Stream Started** and **Sync Stream Completed** log entries.
+Custom metadata appears in the **Service/API logs** section of the [PowerSync Dashboard](https://dashboard.powersync.com/). Navigate to your project and instance, then go to the **Logs** view. The metadata is included in **Sync stream started** and **Sync stream complete** log entries.
 
 <Note>
   Make sure the **Metadata** checkbox is enabled in the logs view to see custom metadata in log entries.

--- a/maintenance-ops/monitoring-and-alerting.mdx
+++ b/maintenance-ops/monitoring-and-alerting.mdx
@@ -114,8 +114,10 @@ You can manage logs with the following options:
 
 When a user reports a sync issue at a specific time, you can find their session in the Service/API logs by filtering on their `user_id`. Two events describe each sync session:
 
-* **Sync stream started**: logged when the client connects. Fields include `user_id`, `client_id`, `app_metadata` (if set), and client parameters.
-* **Sync stream complete**: logged when the session ends. Fields include `user_id`, `app_metadata` (if set), `operations_synced`, `data_synced_bytes`, `data_sent_bytes`, and `stream_ms` (how long the session lasted).
+* **Sync stream started**: logged when the client connects. Fields include `user_id`, `client_id`, `app_metadata` (if set), `client_params`, `user_agent`, and `rid` (request id).
+* **Sync stream complete**: logged when the session ends. Fields include `user_id`, `client_id`, `app_metadata` (if set), `operations_synced`, `operation_counts` (broken down by `put`, `remove`, `move`, `clear`), `data_synced_bytes`, `data_sent_bytes`, `stream_ms` (session duration), `close_reason`, and `rid`.
+
+Both events share the same `rid`, so a started/complete pair for a single session can be matched by filtering on it.
 
 Together these tell you when a user connected, how much data was synced, and how long the connection stayed open. This is useful for investigating reports like "data took a while to appear at 2:15 PM": locate the matching session and inspect its size and duration.
 

--- a/maintenance-ops/monitoring-and-alerting.mdx
+++ b/maintenance-ops/monitoring-and-alerting.mdx
@@ -110,18 +110,16 @@ You can manage logs with the following options:
 
 * **Stack Traces**: Option to show or hide stack traces for errors.
 
-### Correlating User Reports to Sync Sessions
+### Correlating Sync Sessions
 
-When a user reports a sync issue at a specific time, you can find their session in the Service/API logs by filtering on their `user_id`. Two events describe each sync session:
+To find a specific users session in the Service logs, filter on their `user_id`. Two events describe each sync session:
 
 * **Sync stream started**: logged when the client connects. Fields include `user_id`, `client_id`, `app_metadata` (if set), `client_params`, `user_agent`, and `rid` (request id).
 * **Sync stream complete**: logged when the session ends. Fields include `user_id`, `client_id`, `app_metadata` (if set), `operations_synced`, `operation_counts` (broken down by `put`, `remove`, `move`, `clear`), `data_synced_bytes`, `data_sent_bytes`, `stream_ms` (session duration), `close_reason`, and `rid`.
 
 Both events share the same `rid`, so a started/complete pair for a single session can be matched by filtering on it.
 
-Together these tell you when a user connected, how much data was synced, and how long the connection stayed open. This is useful for investigating reports like "data took a while to appear at 2:15 PM": locate the matching session and inspect its size and duration.
-
-For diagnosing sync latency end-to-end, see [Diagnosing Sync Latency](/debugging/troubleshooting#diagnosing-sync-latency).
+For diagnosing sync latency, see [Diagnosing Sync Latency](/debugging/troubleshooting#diagnosing-sync-latency).
 
 ## Custom Metadata in Sync Logs
 


### PR DESCRIPTION
- New Diagnosing Sync Latency section in `troubleshooting.mdx`. Walks through how to measure end-to-end latency with timestamps in the data, then how to narrow it down per stage (source database to service, service to client), with the usual culprits at the bottom
- New Correlating User Reports to Sync Sessions subsection in `monitoring-and-alerting.mdx`, documenting the Sync stream started and Sync stream complete log events and what fields they carry
- Links forward to the new `/maintenance-ops/replication-lag` page for source-specific guidance on replication lag