### PR TITLE
Align error-codes docs with service wording and remove empty sections

### DIFF
--- a/debugging/error-codes.mdx
+++ b/debugging/error-codes.mdx
@@ -6,22 +6,10 @@ sidebarTitle: "Error Codes"
 
 This reference documents PowerSync error codes organized by component, with troubleshooting suggestions for developers. Use the search bar to look up specific error codes (e.g., `PSYNC_R0001`).
 
-# PSYNC_Rxxxx: Sync Rules issues
+# PSYNC_Rxxxx: Sync Config issues
 
 - **PSYNC_R0001**:
-  Catch-all [Sync Rules](/sync/rules/overview) parsing error, if no more specific error is available
-
-## PSYNC_R11xx: YAML syntax issues
-
-## PSYNC_R12xx: YAML structure (schema) issues
-
-## PSYNC_R21xx: SQL syntax issues
-
-## PSYNC_R22xx: SQL supported feature issues
-
-## PSYNC_R23xx: SQL schema mismatch issues
-
-## PSYNC_R24xx: SQL security warnings
+  Catch-all [Sync Config](/sync/overview) parsing error, if no more specific error is available
 
 # PSYNC_Sxxxx: Service issues
 
@@ -48,7 +36,7 @@ This reference documents PowerSync error codes organized by component, with trou
   this cannot be replicated.
 
 - **PSYNC_S1003**:
-  Sync rules have been locked by another process for replication.
+  Replication stream has been locked by another process for replication.
   
   This error is normal in some circumstances:
   1. In some cases, if a process was forcefully terminated, this error may occur for up to a minute.
@@ -153,8 +141,6 @@ This reference documents PowerSync error codes organized by component, with trou
 
   An alternative is to create explicit policies for the replication role. If you have done that,
   you may ignore this warning.
-
-## PSYNC_S12xx: MySQL replication issues
 
 ## PSYNC_S13xx: MongoDB replication issues
 
@@ -322,7 +308,7 @@ This does not include auth configuration errors on the service.
 ## PSYNC_S23xx: Sync API errors
 
 - **PSYNC_S2302**:
-  No sync rules available.
+  No Sync Config available.
   
   This error may happen if:
   1. Sync Streams/Rules have not been deployed.
@@ -353,10 +339,6 @@ This does not include auth configuration errors on the service.
 - **PSYNC_S2404**:
   Query failure on the storage database. See error details for more information.
 
-## PSYNC_S23xx: Sync API errors - Postgres Storage
-
-## PSYNC_S3xxx: Service configuration issues
-
 ## PSYNC_S31xx: Auth configuration issues
 
 - **PSYNC_S3102**:
@@ -378,7 +360,7 @@ This does not include auth configuration errors on the service.
   This error may indicate a bug in the service code.
 
 - **PSYNC_S4104**:
-  No active sync rules.
+  No active Sync Config.
 
 - **PSYNC_S4105**:
   Sync Streams API disabled.


### PR DESCRIPTION
_AI-generated PR using Codex cloud version, then manually reviewed_

Updates error codes with the changes in https://github.com/powersync-ja/powersync-service/pull/626, and remove empty error code sections.

### Changes
- Replaced legacy "Sync Rules" wording with "Sync Config" in the top-level `PSYNC_Rxxxx` section and in specific entries (`PSYNC_R0001`, `PSYNC_S2302`, `PSYNC_S4104`) and updated the link to point at `/sync/overview`.
- Reworded the `PSYNC_S1003` entry to reference a "replication stream" lock instead of "Sync rules" being locked.
- Removed empty subsection headers (e.g., `PSYNC_R11xx: YAML syntax issues`, `PSYNC_S12xx`, `PSYNC_S23xx: Postgres Storage`, `PSYNC_S3xxx`, and other empty groups) so the page only shows sections that contain documented codes.

### Follow-up

- Noted a likely follow-up: the MongoDB storage subsection heading reads `PSYNC_S23xx: Sync API errors - MongoDB Storage` while the codes listed are `PSYNC_S2401`–`PSYNC_S2404`, so the service-side source or templates may need to rename that heading to `PSYNC_S24xx` for consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdb97b14ec832bac0f15b9abcbf641)