### PR TITLE
Mark Room integration as beta

### DIFF
--- a/client-sdks/orms/kotlin/room.mdx
+++ b/client-sdks/orms/kotlin/room.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Room (Alpha)"
+title: "Room (Beta)"
 description: "Use Android Room with PowerSync's Kotlin SDK."
 ---
 
 <Warning>
-    Room support is currently in an alpha release.
+    Room support is currently in a beta release.
 </Warning>
 
 PowerSync supports the Room database library for Kotlin (Multiplatform).

--- a/resources/feature-status.mdx
+++ b/resources/feature-status.mdx
@@ -79,12 +79,12 @@ Below is a summary of the current main PowerSync features and their release stat
 | React Hooks                                          | GA             |
 |                                                    |                |
 | **ORMs/SQL Libraries**                                             |                |
-| Room (Kotlin)                                        | Alpha          |
 | TanStack DB (JS)                                         | Alpha          |
 | GRDB (Swift)                                              | Alpha           |
 | Drift (Flutter)                                        | Beta          |
 | Drizzle (JS)                                              | Beta          |
 | Kysely (JS)                                              | Beta           |
+| Room (Kotlin)                                        | Beta           |
 | SQLDelight (Kotlin)                                              | Beta           |
 |                                                    |                |
 | **Attachment Helpers**                                |                |


### PR DESCRIPTION
Since raw tables are stable, we can mark the integration as beta (https://github.com/powersync-ja/powersync-kotlin/pull/346).