### PR TITLE
Sync Streams GA release

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -170,7 +170,7 @@
             "pages": [
               "sync/overview",
               {
-                "group": "Sync Streams (Beta)",
+                "group": "Sync Streams",
                 "pages": [
                   "sync/streams/overview",
                   "sync/streams/parameters",

--- a/intro/powersync-philosophy.mdx
+++ b/intro/powersync-philosophy.mdx
@@ -26,7 +26,7 @@ Once you have a local SQLite database that is always in sync, [state management]
 
 #### Flexibility
 
-PowerSync allows you to fully customize what data is synced to the client. Syncing the entire database is extremely simple, but it is just as easy to use [Sync Streams](/sync/streams/overview) (or legacy [Sync Rules](/sync/rules/overview)) to transform and filter data for each client (partial sync).
+PowerSync allows you to fully customize what data is synced to the client. Syncing the entire database is extremely simple, but it is just as easy to use [Sync Streams](/sync/streams/overview) (or legacy [Sync Rules](/sync/rules/overview)) to transform and filter data for each client (<Tooltip tip="Syncing only the relevant subset of data to each client, instead of the entire database.">partial sync</Tooltip>).
 
 Writing back to the backend source database [is in full control of the developer](/handling-writes/writing-client-changes) — use your own authentication, validation, and constraints.
 

--- a/intro/setup-guide.mdx
+++ b/intro/setup-guide.mdx
@@ -477,109 +477,58 @@ The next step is to connect your PowerSync Service instance to your source datab
 
 # 4. Define Sync Streams
 
-PowerSync uses either **Sync Streams** (or legacy **Sync Rules**) to control which data gets synced to which users/devices. Both use SQL-like queries defined in YAML format.
+PowerSync uses **Sync Streams** to control which data gets synced to which users/devices, using SQL-like queries defined in YAML format.
 
-<Tabs>
-  <Tab title="Sync Streams (Recommended)">
+Start with simple **auto-subscribed streams** that sync data to all users by default:
 
-  Sync Streams are now in beta and production-ready. We recommend Sync Streams for new projects — they offer a simpler syntax and support on-demand syncing for web apps.
+<CodeGroup>
+```yaml Postgres Example
+config:
+  edition: 3
+streams:
+  shared_data:
+    auto_subscribe: true
+    queries:
+      - SELECT * FROM todos
+      - SELECT * FROM lists WHERE NOT archived
+```
 
-  Start with simple **auto-subscribed streams** that sync data to all users by default:
+```yaml MongoDB Example
+config:
+  edition: 3
+streams:
+  shared_data:
+    auto_subscribe: true
+    # MongoDB uses "_id" but PowerSync uses "id" on the client
+    queries:
+      - SELECT _id as id, * FROM lists
+      - SELECT _id as id, * FROM todos WHERE archived = false
+```
 
-  <CodeGroup>
-  ```yaml Postgres Example
-  config:
-    edition: 3
-  streams:
-    shared_data:
-      auto_subscribe: true
-      queries:
-        - SELECT * FROM todos
-        - SELECT * FROM lists WHERE NOT archived
-  ```
+```yaml MySQL Example
+config:
+  edition: 3
+streams:
+  shared_data:
+    auto_subscribe: true
+    queries:
+      - SELECT * FROM todos
+      - SELECT * FROM lists WHERE NOT archived
+```
 
-  ```yaml MongoDB Example
-  config:
-    edition: 3
-  streams:
-    shared_data:
-      auto_subscribe: true
-      # MongoDB uses "_id" but PowerSync uses "id" on the client
-      queries:
-        - SELECT _id as id, * FROM lists
-        - SELECT _id as id, * FROM todos WHERE archived = false
-  ```
+```yaml SQL Server Example
+config:
+  edition: 3
+streams:
+  shared_data:
+    auto_subscribe: true
+    queries:
+      - SELECT * FROM todos
+      - SELECT * FROM lists WHERE NOT archived
+```
+</CodeGroup>
 
-  ```yaml MySQL Example
-  config:
-    edition: 3
-  streams:
-    shared_data:
-      auto_subscribe: true
-      queries:
-        - SELECT * FROM todos
-        - SELECT * FROM lists WHERE NOT archived
-  ```
-
-  ```yaml SQL Server Example
-  config:
-    edition: 3
-  streams:
-    shared_data:
-      auto_subscribe: true
-      queries:
-        - SELECT * FROM todos
-        - SELECT * FROM lists WHERE NOT archived
-  ```
-  </CodeGroup>
-
-  **Learn more:** [Sync Streams documentation](/sync/streams/overview)
-
-  </Tab>
-
-  <Tab title="Sync Rules (Legacy)">
-
-  Sync Rules is the original system for controlling data sync. Use this if you prefer a fully released (non-beta) solution.
-
-  <CodeGroup>
-  ```yaml Postgres Example
-  bucket_definitions:
-    global:
-      data:
-        - SELECT * FROM todos
-        - SELECT * FROM lists WHERE archived = false
-  ```
-
-  ```yaml MongoDB Example
-  bucket_definitions:
-    global:
-      data:
-        # MongoDB uses "_id" but PowerSync uses "id" on the client
-        - SELECT _id as id, * FROM lists
-        - SELECT _id as id, * FROM todos WHERE archived = false
-  ```
-
-  ```yaml MySQL Example
-  bucket_definitions:
-    global:
-      data:
-        - SELECT * FROM todos
-        - SELECT * FROM lists WHERE archived = 0
-  ```
-
-  ```yaml SQL Server Example
-  bucket_definitions:
-    global:
-      data:
-        - SELECT * FROM todos
-        - SELECT * FROM lists WHERE archived = 0
-  ```
-  </CodeGroup>
-
-  **Learn more:** [Sync Rules documentation](/sync/rules/overview)
-
-  </Tab>
-</Tabs>
+**Learn more:** [Sync Streams documentation](/sync/streams/overview)
 
 
 ### Deploy Your Configuration
@@ -589,9 +538,9 @@ PowerSync uses either **Sync Streams** (or legacy **Sync Rules**) to control whi
     In the [PowerSync Dashboard](https://dashboard.powersync.com/):
 
     1. Select your project and instance
-    2. Go to the **Sync Streams** or **Sync Rules** view (depending on which you’re using)
+    2. Go to the **Sync Streams** view
     3. Edit the YAML directly in the dashboard
-    4. Click **Deploy** to validate and deploy your Sync Rules
+    4. Click **Deploy** to validate and deploy your Sync Streams
   </Tab>
 
   <Tab title="CLI (Cloud)">
@@ -623,7 +572,7 @@ PowerSync uses either **Sync Streams** (or legacy **Sync Rules**) to control whi
       path: sync-config.yaml
     ```
 
-    Put your streams or rules in `sync-config.yaml` (see [Self-Hosted Instance Configuration](/configuration/powersync-service/self-hosted-instances#sync-streams--sync-rules) for full examples). Alternatively, you can use inline `content: |` with the YAML nested under `sync_config`.
+    Put your streams in `sync-config.yaml` (see [Self-Hosted Instance Configuration](/configuration/powersync-service/self-hosted-instances#sync-streams--sync-rules) for full examples). Alternatively, you can use inline `content: |` with the YAML nested under `sync_config`.
   </Tab>
 </Tabs>
 
@@ -637,7 +586,7 @@ Table/collection names in your configuration must match the table names defined 
 For quick development and testing, you can generate a temporary development token instead of implementing full authentication.
 
 You'll use this token for two purposes:
-- **Testing with the _Sync Diagnostics Client_** (in the next step) to verify your setup and Sync Streams (or legacy Sync Rules)
+- **Testing with the _Sync Diagnostics Client_** (in the next step) to verify your setup and Sync Streams
 - **Connecting your app** (in a later step) to test the client SDK integration
 
 <Tabs>
@@ -718,7 +667,7 @@ The Sync Diagnostics Client will connect to your PowerSync Service instance and 
 <Check>
   **Checkpoint:**
 
-  Inspect your synced tables in the Sync Diagnostics Client — these should match the Sync Streams/Sync Rules you [defined previously](#4-define-sync-streams-or-sync-rules). This confirms your setup is working correctly before integrating the client SDK into your app.
+  Inspect your synced tables in the Sync Diagnostics Client — these should match the Sync Streams you [defined previously](#4-define-sync-streams). This confirms your setup is working correctly before integrating the client SDK into your app.
 </Check>
 
 # 7. Use the Client SDK
@@ -777,7 +726,7 @@ import SdkClientSideSchema from '/snippets/sdk-client-side-schema.mdx';
 
 <SdkClientSideSchema />
 
-_PowerSync Cloud:_ The easiest way to generate your schema is using the [PowerSync Dashboard](https://dashboard.powersync.com/). Click the **Connect** button in the top bar to generate the client-side schema based on your Sync Streams/Sync Rules in your preferred language.
+_PowerSync Cloud:_ The easiest way to generate your schema is using the [PowerSync Dashboard](https://dashboard.powersync.com/). Click the **Connect** button in the top bar to generate the client-side schema based on your Sync Streams in your preferred language.
 
 Here's an example schema for a simple `todos` table:
 
@@ -792,12 +741,12 @@ import SdkSchemaExamples from '/snippets/sdk-schema-examples.mdx';
 <Tip>
   **Learn More**
   
-  The client-side schema uses three column types: `text`, `integer`, and `real`. These map directly to values from your Sync Streams/Sync Rules and are automatically cast if needed. For details on how backend database types map to SQLite types, see [Types](/sync/types).
+  The client-side schema uses three column types: `text`, `integer`, and `real`. These map directly to values from your Sync Streams and are automatically cast if needed. For details on how backend database types map to SQLite types, see [Types](/sync/types).
 </Tip>
 
 ### Instantiate the PowerSync Database
 
-Now that you have your client-side schema defined, instantiate the PowerSync database in your app. This creates the client-side SQLite database that will be kept in sync with your source database based on your Sync Streams/Sync Rules.
+Now that you have your client-side schema defined, instantiate the PowerSync database in your app. This creates the client-side SQLite database that will be kept in sync with your source database based on your Sync Streams.
 
 import SdkInstantiateDbExamples from '/snippets/sdk-instantiate-db-examples.mdx';
 
@@ -1463,7 +1412,7 @@ For production deployments, you'll need to:
 
 ### Additional Resources
 
-- Learn more about [Sync Streams](/sync/streams/overview) or [Sync Rules](/sync/rules/overview) for controlling partial syncing.
+- Learn more about [Sync Streams](/sync/streams/overview) for controlling partial syncing.
 - Explore [Live Queries / Watch Queries](/client-sdks/watch-queries) for reactive UI updates.
 - Check out [Example Projects](/intro/examples) for complete implementations.
 - Review the [Client SDK References](/client-sdks/overview) for client-side platform-specific details.

--- a/intro/setup-guide.mdx
+++ b/intro/setup-guide.mdx
@@ -572,7 +572,7 @@ streams:
       path: sync-config.yaml
     ```
 
-    Put your streams in `sync-config.yaml` (see [Self-Hosted Instance Configuration](/configuration/powersync-service/self-hosted-instances#sync-streams--sync-rules) for full examples). Alternatively, you can use inline `content: |` with the YAML nested under `sync_config`.
+    Put your streams in `sync-config.yaml` (see [Self-Hosted Instance Configuration](/configuration/powersync-service/self-hosted-instances#sync-streams) for full examples). Alternatively, you can use inline `content: |` with the YAML nested under `sync_config`.
   </Tab>
 </Tabs>
 
@@ -760,7 +760,7 @@ Connect your client-side PowerSync database to the PowerSync Service instance yo
 
 <Note>You don't have to worry about the _backend connector_ implementation details right now — you can leave the boilerplate as-is and come back to it later.</Note>
 
-For development, you can use the development token you generated in the [Generate a Development Token](#optional-generate-a-development-token) step above. For production, you'll implement proper JWT authentication as we'll explain further below.
+For development, you can use the development token you generated in the [Generate a Development Token](#5-generate-a-development-token) step above. For production, you'll implement proper JWT authentication as we'll explain further below.
 
 <CodeGroup>
   ```typescript React Native (TS)

--- a/migration-guides/atlas-device-sync.mdx
+++ b/migration-guides/atlas-device-sync.mdx
@@ -74,7 +74,7 @@ Follow the steps for MongoDB and your client platform/framework in our standard 
 * [Configure Your Source Database](/intro/setup-guide#1-configure-your-source-database)
 * [Set Up PowerSync Service Instance](/intro/setup-guide#2-set-up-powersync-service-instance)
 * [Connect PowerSync To Your Source Database](/intro/setup-guide#3-connect-powersync-to-your-source-database) (MongoDB)
-* [Define Sync Streams or Sync Rules](/intro/setup-guide#4-define-sync-streams-or-sync-rules)
+* [Define Sync Streams](/intro/setup-guide#4-define-sync-streams)
 * [Generate a Development Token](/intro/setup-guide#5-generate-a-development-token)
 * [Test Sync with the Sync Diagnostics Client](/intro/setup-guide#6-%5Boptional%5D-test-sync-with-the-sync-diagnostics-client)
 * [Use the Client SDK](/intro/setup-guide#7-use-the-client-sdk)

--- a/migration-guides/atlas-device-sync.mdx
+++ b/migration-guides/atlas-device-sync.mdx
@@ -27,8 +27,6 @@ By introducing PowerSync as a sync engine, you get:
 * **Real-time multi-user applications** as data updates are streamed to connected clients in real-time.
 * **Offline-first capabilities** enabling apps to continue to work regardless of network conditions.
 
-Please review this guide to understand the required changes and prerequisites. Following the provided steps will help your team transition smoothly.
-
 If you need further assistance at any point, you can:
 * **Ask AI** (see lower right corner of this site), which is trained on all our documentation, repositories and Discord discussions. 
 * [Set up a call](https://calendly.com/powersync/powersync-chat) with us.
@@ -38,11 +36,15 @@ If you need further assistance at any point, you can:
 ## Architecture: Before and After
 If you have MongoDB Atlas Device Sync deployed today, at a high level your architecture will look something like this:
 
-<img src="/images/migration-guides/mongodb-before.png" />
+<Frame caption="Architecture before migration: MongoDB Atlas Device Sync setup">
+  <img src="/images/migration-guides/mongodb-before.png" />
+</Frame>
 
 Migrating to PowerSync results in this architecture: (new components in green)
 
-<img src="/images/migration-guides/mongodb-after.png" />
+<Frame caption="Architecture after migration: PowerSync replacing Atlas Device Sync">
+  <img src="/images/migration-guides/mongodb-after.png" />
+</Frame>
 
 Here is a quick overview of the resulting PowerSync architecture:
 * The **PowerSync Service** is the server-side component of PowerSync. It's available as a cloud-hosted service ([PowerSync Cloud](https://powersync.com/pricing)), or you can [self-host](/intro/self-hosting) using our Open Edition.
@@ -124,7 +126,7 @@ For more information, see our blog post: [Turnkey Backend Functionality & Confli
 
 ### 3. Set Up Authentication Integration
 
-For quick development and testing purposes, the _Setup Guide_ from step 1 instructions you to generate a temporary development token to use for authentication.
+For quick development and testing purposes, the _Setup Guide_ from step 1 instructs you to generate a temporary development token to use for authentication.
 
 At some point you will need to replace the development tokens with proper JWT-based authentication integration. PowerSync supports various authentication providers including Supabase, Firebase Auth, Auth0, Clerk, and custom JWT implementations.
 

--- a/resources/feature-status.mdx
+++ b/resources/feature-status.mdx
@@ -25,7 +25,7 @@ The latest stable PowerSync Docker image is available under the latest tag and c
 docker pull journeyapps/powersync-service:latest
 ```
 
-Development images may be released for bleeding edge feature additions or hotfix testing purposes. These images are usually versioned as a `0.0.0-dev-XXXXXXXXXXXXXX` prereleases.
+Development images may be released for bleeding edge feature additions or hotfix testing purposes. These images are usually versioned as a `0.0.0-dev-XXXXXXXXXXXXXX` pre-releases.
 
 ## PowerSync Cloud 
 

--- a/resources/feature-status.mdx
+++ b/resources/feature-status.mdx
@@ -54,7 +54,7 @@ Below is a summary of the current main PowerSync features and their release stat
 | **PowerSync Service**                                |                |
 | Open Edition                      | GA |
 | Enterprise Self-Hosted                       | GA |
-| Sync Streams                                         | Beta           |
+| Sync Streams                                         | GA             |
 | Postgres Bucket Storage                              | GA           |
 |                                                    |                |
 | **Client SDKs**                                      |                |

--- a/resources/feature-status.mdx
+++ b/resources/feature-status.mdx
@@ -33,7 +33,7 @@ In the PowerSync Dashboard, you can configure the service version channel for yo
 
 ### Stable
 
-The Stable channel provides the most reliable release of the PowerSync Service. It includes features that may be in the `GA`, `Beta`, or `Open Alpha` stages. `Open Alpha` features in this channel are typically mature but may still have bugs or known issues.
+The Stable channel provides the most reliable release of the PowerSync Service. It includes features that may be in the GA, Beta, or Open Alpha stages. Open Alpha features in this channel are typically mature but may still have bugs or known issues.
 
 ### Next
 

--- a/snippets/dev-token-self-hosted-steps.mdx
+++ b/snippets/dev-token-self-hosted-steps.mdx
@@ -91,8 +91,8 @@
         ```
 
         Replace `test-user` with the user ID you want to authenticate:
-        - If your Sync Streams/Rules data isn't filtered by user (same data syncs to all users), you can use any value (e.g., `test-user`).
-        - If your data is filtered by <Tooltip tip="Values such as user ID that are used to determine which data syncs to which user.">parameters</Tooltip>, use a user ID that matches a user in your database. PowerSync uses this (e.g. `auth.user_id()` in Sync Streams or `request.user_id()` in Sync Rules) to determine what to sync.
+        - If your Sync Streams aren't filtered by user (same data syncs to all users), you can use any value (e.g., `test-user`).
+        - If your data is filtered by <Tooltip tip="Values such as user ID that are used to determine which data syncs to which user.">parameters</Tooltip>, use a user ID that matches a user in your database. PowerSync uses this value (e.g. via `auth.user_id()`) to determine what to sync.
       </Tab>
 
       <Tab title="test-client">
@@ -107,8 +107,8 @@
         ```
 
         Replace `test-user` with the user ID you want to authenticate:
-        - If your Sync Streams/Rules data isn't filtered by user (same data syncs to all users), you can use any value (e.g., `test-user`).
-        - If your data is filtered by <Tooltip tip="Values such as user ID that are used to determine which data syncs to which user.">parameters</Tooltip>, use a user ID that matches a user in your database. PowerSync uses this (e.g. `auth.user_id()` in Sync Streams or `request.user_id()` in Sync Rules) to determine what to sync.
+        - If your Sync Streams aren't filtered by user (same data syncs to all users), you can use any value (e.g., `test-user`).
+        - If your data is filtered by <Tooltip tip="Values such as user ID that are used to determine which data syncs to which user.">parameters</Tooltip>, use a user ID that matches a user in your database. PowerSync uses this value (e.g. via `auth.user_id()`) to determine what to sync.
       </Tab>
     </Tabs>
   </Step> 

--- a/sync/overview.mdx
+++ b/sync/overview.mdx
@@ -7,9 +7,9 @@ description: "PowerSync Sync Streams and the legacy Sync Rules allow developers 
 
 ## Sync Streams — Recommended
 
-<Note>Sync Streams are now [generally available](/resources/feature-status).</Note>
+With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data, and clients subscribe to the streams they need. Sync Streams are now [generally available](/resources/feature-status) and the recommended path to partial sync for both new and existing projects: they support everything legacy Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, warm-cache TTL behavior, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
 
-With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data, and clients subscribe to the streams they need. Sync Streams are the recommended approach for new and existing projects, giving you the flexibility to dynamically sync data on-demand, or to sync data upfront for offline-first use cases. If you're using legacy Sync Rules, see the [migration guide](/sync/streams/migration).
+If you're using legacy Sync Rules, we recommend migrating to future-proof your project. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
 
 Key improvements in Sync Streams over legacy Sync Rules include:
 - **On-demand syncing**: You define Sync Streams on the PowerSync Service, and a client can then subscribe to them one or more times with different parameters, on-demand. You still have the option of auto-subscribing streams when a client connects, for "sync data upfront" behavior.

--- a/sync/overview.mdx
+++ b/sync/overview.mdx
@@ -7,14 +7,14 @@ description: "PowerSync Sync Streams and the legacy Sync Rules allow developers 
 
 ## Sync Streams — Recommended
 
-With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data, and clients subscribe to the streams they need. Sync Streams are [generally available](/resources/feature-status) and the recommended path to achievepartial sync for both new and existing projects.
+With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data. Clients subscribe to the streams they need, either on-demand or automatically on connect. Sync Streams are the recommended path to achieve <Tooltip tip="Syncing only the relevant subset of data to each client, instead of the entire database.">partial sync</Tooltip> for both new and existing projects.
 
 Key improvements in Sync Streams over legacy Sync Rules include:
 - **On-demand syncing**: You define Sync Streams on the PowerSync Service, and a client can then subscribe to them one or more times with different parameters, on-demand. You still have the option of auto-subscribing streams when a client connects, for "sync data upfront" behavior.
 - **Temporary caching-like behavior**: Each subscription includes a configurable TTL that keeps data active after the client unsubscribes, acting as a warm cache for re-subscribing.
 - **Simpler developer experience**: Simplified syntax and mental model, and capabilities such as your UI components automatically managing subscriptions (for example, React hooks).
 
-If you're using legacy Sync Rules, we recommend migrating to future-proof your project. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
+If you're on Sync Rules, you can migrate in a few clicks. Click **Migrate to Sync Streams** in the PowerSync Dashboard, or run `powersync migrate sync-rules` in the CLI to generate a draft from your current config. See the [migration guide](/sync/streams/migration) for details.
 
 <Card title="Sync Streams" horizontal icon="box-check" href="/sync/streams/overview" />
 

--- a/sync/overview.mdx
+++ b/sync/overview.mdx
@@ -7,14 +7,14 @@ description: "PowerSync Sync Streams and the legacy Sync Rules allow developers 
 
 ## Sync Streams — Recommended
 
-With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data, and clients subscribe to the streams they need. Sync Streams are now [generally available](/resources/feature-status) and the recommended path to partial sync for both new and existing projects: they support everything legacy Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, warm-cache TTL behavior, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
-
-If you're using legacy Sync Rules, we recommend migrating to future-proof your project. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
+With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data, and clients subscribe to the streams they need. Sync Streams are [generally available](/resources/feature-status) and the recommended path to achievepartial sync for both new and existing projects.
 
 Key improvements in Sync Streams over legacy Sync Rules include:
 - **On-demand syncing**: You define Sync Streams on the PowerSync Service, and a client can then subscribe to them one or more times with different parameters, on-demand. You still have the option of auto-subscribing streams when a client connects, for "sync data upfront" behavior.
 - **Temporary caching-like behavior**: Each subscription includes a configurable TTL that keeps data active after the client unsubscribes, acting as a warm cache for re-subscribing.
 - **Simpler developer experience**: Simplified syntax and mental model, and capabilities such as your UI components automatically managing subscriptions (for example, React hooks).
+
+If you're using legacy Sync Rules, we recommend migrating to future-proof your project. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
 
 <Card title="Sync Streams" horizontal icon="box-check" href="/sync/streams/overview" />
 

--- a/sync/overview.mdx
+++ b/sync/overview.mdx
@@ -7,9 +7,9 @@ description: "PowerSync Sync Streams and the legacy Sync Rules allow developers 
 
 ## Sync Streams — Recommended
 
-<Note>Sync Streams is currently in a [Beta release](/resources/feature-status) and considered production-ready.</Note>
+<Note>Sync Streams are now [generally available](/resources/feature-status).</Note>
 
-[Sync Streams](/sync/streams/overview) are recommended for all new projects. We recommend Sync Streams for all new projects, and encourage existing projects to [migrate](/sync/streams/migration). Sync Streams are designed to give developers flexibility to either dynamically sync data on-demand, or to "sync data upfront"  for offline-first use cases. 
+With [Sync Streams](/sync/streams/overview), you write SQL-like queries to define streams of data, and clients subscribe to the streams they need. Sync Streams are the recommended approach for new and existing projects, giving you the flexibility to dynamically sync data on-demand, or to sync data upfront for offline-first use cases. If you're using legacy Sync Rules, see the [migration guide](/sync/streams/migration).
 
 Key improvements in Sync Streams over legacy Sync Rules include:
 - **On-demand syncing**: You define Sync Streams on the PowerSync Service, and a client can then subscribe to them one or more times with different parameters, on-demand. You still have the option of auto-subscribing streams when a client connects, for "sync data upfront" behavior.

--- a/sync/rules/overview.mdx
+++ b/sync/rules/overview.mdx
@@ -4,15 +4,15 @@ sidebarTitle: "Overview & Key Concepts"
 description: "Understand legacy Sync Rules for controlling which data syncs to each client."
 ---
 
-PowerSync Sync Rules is the legacy mechanism to control which data gets synced to which clients/devices (i.e. they enable _partial sync_).
+Sync Rules are PowerSync's original system for <Tooltip tip="Syncing only the relevant subset of data to each client, instead of the entire database.">partial sync</Tooltip>, using YAML bucket definitions. They remain supported for existing projects but are considered legacy.
 
-<Warning>
+<Tip>
 **Sync Streams Recommended**
 
-[Sync Streams](/sync/streams/overview) are now generally available and the recommended approach to partial sync for both new and existing projects. They support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
+[Sync Streams](/sync/streams/overview) are the recommended approach to partial sync for both new and existing projects. They support everything Sync Rules do, plus more expressive queries (including JOIN support), on-demand syncing, and a simpler developer experience (e.g. React hooks that manage subscriptions automatically).
 
-We recommend that existing projects [migrate to Sync Streams](/sync/streams/migration) to future-proof their config. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config.
-</Warning>
+You can migrate in a few clicks. Click **Migrate to Sync Streams** in the PowerSync Dashboard, or run `powersync migrate sync-rules` in the CLI to generate a draft from your current config.
+</Tip>
 
 Sync Rules are defined in a YAML file. For PowerSync Cloud, they are edited and deployed to a specific PowerSync instance in the [PowerSync Dashboard](/tools/powersync-dashboard#project-&-instance-level). For self-hosting setups, they are defined as part of your [instance configuration](/configuration/powersync-service/self-hosted-instances).
 

--- a/sync/rules/overview.mdx
+++ b/sync/rules/overview.mdx
@@ -9,9 +9,9 @@ PowerSync Sync Rules is the legacy mechanism to control which data gets synced t
 <Warning>
 **Sync Streams Recommended**
 
-[Sync Streams](/sync/streams/overview) are now generally available and the recommended approach for all new projects. They offer a simpler developer experience, on-demand syncing with subscription parameters, and caching-like behavior with TTL.
+[Sync Streams](/sync/streams/overview) are now generally available and the recommended approach to partial sync for both new and existing projects. They support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, warm-cache TTL behavior, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
 
-Existing projects should [migrate to Sync Streams](/sync/streams/migration). Sync Rules remain supported but are considered legacy.
+We recommend that existing projects [migrate to Sync Streams](/sync/streams/migration) to future-proof their config. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config.
 </Warning>
 
 Sync Rules are defined in a YAML file. For PowerSync Cloud, they are edited and deployed to a specific PowerSync instance in the [PowerSync Dashboard](/tools/powersync-dashboard#project-&-instance-level). For self-hosting setups, they are defined as part of your [instance configuration](/configuration/powersync-service/self-hosted-instances).

--- a/sync/rules/overview.mdx
+++ b/sync/rules/overview.mdx
@@ -9,7 +9,7 @@ PowerSync Sync Rules is the legacy mechanism to control which data gets synced t
 <Warning>
 **Sync Streams Recommended**
 
-[Sync Streams](/sync/streams/overview) are now generally available and the recommended approach to partial sync for both new and existing projects. They support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, warm-cache TTL behavior, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
+[Sync Streams](/sync/streams/overview) are now generally available and the recommended approach to partial sync for both new and existing projects. They support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
 
 We recommend that existing projects [migrate to Sync Streams](/sync/streams/migration) to future-proof their config. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config.
 </Warning>

--- a/sync/rules/overview.mdx
+++ b/sync/rules/overview.mdx
@@ -9,7 +9,7 @@ PowerSync Sync Rules is the legacy mechanism to control which data gets synced t
 <Warning>
 **Sync Streams Recommended**
 
-[Sync Streams](/sync/streams/overview) are now in beta and production-ready. We recommend Sync Streams for all new projects — they offer a simpler developer experience, on-demand syncing with subscription parameters, and caching-like behavior with TTL. 
+[Sync Streams](/sync/streams/overview) are now generally available and the recommended approach for all new projects. They offer a simpler developer experience, on-demand syncing with subscription parameters, and caching-like behavior with TTL.
 
 Existing projects should [migrate to Sync Streams](/sync/streams/migration). Sync Rules remain supported but are considered legacy.
 </Warning>

--- a/sync/streams/migration.mdx
+++ b/sync/streams/migration.mdx
@@ -31,7 +31,7 @@ Sync Streams address these limitations:
 
 4. **Simpler, more powerful syntax**: Queries with subqueries, JOINs, and CTEs. No separate [parameter queries](/sync/rules/overview#parameter-queries). The syntax is closer to plain SQL and supports more SQL features than Sync Rules.
 
-5. **Framework integration**: [React hooks and Kotlin Compose](/sync/streams/client-usage#framework-integrations) extensions let your UI components automatically manage subscriptions based on what's rendered.
+5. **Framework integration**: [React hooks, Vue composables, TanStack Query, and Kotlin Compose extensions](/sync/streams/client-usage#framework-integrations) let your UI components automatically manage subscriptions based on what's rendered.
 
 ### Still Need Offline-First?
 

--- a/sync/streams/overview.mdx
+++ b/sync/streams/overview.mdx
@@ -11,9 +11,9 @@ Instead of syncing entire tables, you tell PowerSync exactly which data each use
 For example, you might create a stream that syncs only the current user's to-do items, another for shared projects they have access to, and another for reference data that everyone needs. Your app subscribes to these streams on demand, and only that data syncs to the client-side SQLite database. Offline-first apps that need all relevant data available upfront can use `auto_subscribe: true` so streams sync automatically when clients connect.
 
 <Note>
-**Are you still using Sync Rules?** Sync Streams support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
+**Are you still using Sync Rules?** Sync Streams support everything Sync Rules do, plus more expressive queries (including JOIN support), on-demand syncing, and a simpler developer experience (e.g. React hooks that manage subscriptions automatically).
 
-We strongly recommend migrating to future-proof your project. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
+You can migrate in a few clicks. Click **Migrate to Sync Streams** in the PowerSync Dashboard, or run `powersync migrate sync-rules` in the CLI to generate a draft from your current config. See the [migration guide](/sync/streams/migration) for details.
 </Note>
 
 ## Defining Streams

--- a/sync/streams/overview.mdx
+++ b/sync/streams/overview.mdx
@@ -11,7 +11,9 @@ Instead of syncing entire tables, you tell PowerSync exactly which data each use
 For example, you might create a stream that syncs only the current user's to-do items, another for shared projects they have access to, and another for reference data that everyone needs. Your app subscribes to these streams on demand, and only that data syncs to the client-side SQLite database. Offline-first apps that need all relevant data available upfront can use `auto_subscribe: true` so streams sync automatically when clients connect.
 
 <Note>
-Sync Streams are now [generally available](/resources/feature-status) and the recommended approach for new and existing projects. If you're using legacy Sync Rules, see the [migration guide](/sync/streams/migration).
+**Are you still using Sync Rules?** Sync Streams support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, warm-cache TTL behavior, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
+
+We strongly recommend migrating to future-proof your project. Sync Streams is where ongoing development is happening. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
 </Note>
 
 ## Defining Streams

--- a/sync/streams/overview.mdx
+++ b/sync/streams/overview.mdx
@@ -11,11 +11,7 @@ Instead of syncing entire tables, you tell PowerSync exactly which data each use
 For example, you might create a stream that syncs only the current user's to-do items, another for shared projects they have access to, and another for reference data that everyone needs. Your app subscribes to these streams on demand, and only that data syncs to the client-side SQLite database. Offline-first apps that need all relevant data available upfront can use `auto_subscribe: true` so streams sync automatically when clients connect.
 
 <Note>
-**Beta Release**
-
-Sync Streams are now in beta and production-ready. We recommend Sync Streams for all new projects, and encourage existing projects to [migrate from Sync Rules](/sync/streams/migration).
-
-We welcome your feedback — please share with us in [Discord](https://discord.gg/powersync).
+Sync Streams are now [generally available](/resources/feature-status) and the recommended approach for new and existing projects. If you're using legacy Sync Rules, see the [migration guide](/sync/streams/migration).
 </Note>
 
 ## Defining Streams

--- a/sync/streams/overview.mdx
+++ b/sync/streams/overview.mdx
@@ -11,9 +11,9 @@ Instead of syncing entire tables, you tell PowerSync exactly which data each use
 For example, you might create a stream that syncs only the current user's to-do items, another for shared projects they have access to, and another for reference data that everyone needs. Your app subscribes to these streams on demand, and only that data syncs to the client-side SQLite database. Offline-first apps that need all relevant data available upfront can use `auto_subscribe: true` so streams sync automatically when clients connect.
 
 <Note>
-**Are you still using Sync Rules?** Sync Streams support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, warm-cache TTL behavior, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
+**Are you still using Sync Rules?** Sync Streams support everything Sync Rules do, plus add more expressive queries (including JOIN support), on-demand syncing, and a significantly simpler developer experience (e.g. React hooks that manage subscriptions automatically).
 
-We strongly recommend migrating to future-proof your project. Sync Streams is where ongoing development is happening. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
+We strongly recommend migrating to future-proof your project. Migration is straightforward: use the **Migrate to Sync Streams** button in the PowerSync Dashboard or run `powersync migrate sync-rules` in the CLI to generate a Sync Streams draft from your current config. See the [migration guide](/sync/streams/migration) for details.
 </Note>
 
 ## Defining Streams


### PR DESCRIPTION
Key changes:
- Removed beta labels
- The Setup Guide now only mentions Sync Streams
- Added why we recommend Sync Streams over Sync Rules, including saying that they support everything that Sync Rules do, and more: Joins, on-demand sync, better DX primarily
- Defined "partial sync" with an on-hover tooltip since it might not be intuitive to all
- Fixed a few broken hyperlinks that the docs-reviewer command picked up, and some other stylistic/wording polish

🤖 Claude Code (Opus) did most of the actual work - I reviewed all updates and iterated via prompts to get the style/wording right.