### PR TITLE
Update Swift SDK docs

### DIFF
--- a/client-sdks/reference/swift.mdx
+++ b/client-sdks/reference/swift.mdx
@@ -26,8 +26,8 @@ import LocalOnly from '/snippets/local-only-escape.mdx';
 </CardGroup>
 
 <Note>
-  Earlier versions of the Swift SDK (up to v1.13) shipped a PowerSync Kotlin XCFramework under the hood and abstracted it behind Swift protocols. 
-  
+  Earlier versions of the Swift SDK (up to v1.13) shipped a PowerSync Kotlin XCFramework under the hood and abstracted it behind Swift protocols.
+
   From v1.14 onward, the Kotlin dependency has been removed entirely. The SDK is now implemented natively in Swift, with the PowerSync sync protocol and SQLite extension handled by our [Rust core](https://github.com/powersync-ja/powersync-sqlite-core). 
 </Note>
 
@@ -137,9 +137,8 @@ import PowerSync
 
 final class MyConnector: PowerSyncBackendConnectorProtocol {
     func fetchCredentials() async throws -> PowerSyncCredentials? {
-    // implement fetchCredentials to obtain the necessary credentials to connect to your backend
-    // See an example implementation in https://github.com/powersync-ja/powersync-swift/blob/main/Demo/PowerSyncExample/PowerSync/SupabaseConnector.swift
-
+        // implement fetchCredentials to obtain the necessary credentials to connect to your backend
+        // See an example implementation in https://github.com/powersync-ja/powersync-swift/blob/main/Demo/PowerSyncExample/PowerSync/SupabaseConnector.swift
         return PowerSyncCredentials(
             endpoint: "Your PowerSync instance URL or self-hosted endpoint",
             // Use a development token (see Authentication Setup https://docs.powersync.com/configuration/auth/development-tokens)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "powersync-docs",
   "version": "1.0.0",
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
   "scripts": {
     "dev": "mintlify dev",
     "check:links": "mintlify broken-links"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  keytar: false
+  puppeteer: false
+  sharp: false

--- a/resources/supported-platforms.mdx
+++ b/resources/supported-platforms.mdx
@@ -102,11 +102,11 @@ Requires Capacitor 8 or later. See the [Capacitor v8 upgrade guide](https://capa
 | --- | --- | --- |
 | macOS | Yes | |
 | iOS | Yes | |
-| watchOS | Yes | watchOS 26 not supported yet |
+| watchOS | Yes | |
 | iPadOS | Yes | |
 | tvOS | Yes | Added in v1.11.0 |
-| macOS Catalyst | No | KT-40442 Support building Kotlin/Native for Mac Catalyst (x86-64 and arm64) |
-| visionOS | No | KT-59571 Add support for visionOS SDK |
+| macOS Catalyst | No | Please [reach out](https://github.com/powersync-ja/powersync-swift/issues/138) if you're interested. |
+| visionOS | No | Please [reach out](https://github.com/powersync-ja/powersync-swift/issues/138) if you're interested. |
 | Non-apple targets (Linux, Windows) | No | No good way to link PowerSync |
 | HTTP connection method | Yes | |
 | WebSocket connection method | No | |


### PR DESCRIPTION
The main documentation site for the Swift SDK already covers the upcoming 1.14.0 release (mentioning that the Kotlin XCFramework is no longer required).

I went through a few related pages and couldn't really find anything worth updating (which is a good thing, the public API is supposed to be unchanged). The only outdated info I could spot is related to macOS Catalyst and visionOS support, Kotlin is no longer a blocker for that and I've opened a Swift SDK issue in case anyone is interested in that.

Finally, this updates pnpm to version 11 for local development, giving us slightly better supply chain security by default.

closes https://github.com/powersync-ja/powersync-docs/issues/427.