### PR TITLE
Document `unstable_sqlite_expression_engine`

### DIFF
--- a/sync/advanced/compatibility.mdx
+++ b/sync/advanced/compatibility.mdx
@@ -99,7 +99,7 @@ This table lists all fixes currently supported:
 | `versioned_bucket_ids`     | [Link](#versioned-bucket-ids)      | 1.15.0       | 2                |
 | `fixed_json_extract`       | [Link](#fixed-json-extract)        | 1.15.0       | 2                |
 | `custom_postgres_types`    | [Link](#custom-postgres-types).    | 1.15.3       | 2                |
-| `unstable_sqlite_expression_engine`    | [Link](#custom-postgres-types).    | 1.22.0       | None (unstable)           |
+| `unstable_sqlite_expression_engine`    | [Link](#unstable_sqlite_expression_engine).    | 1.22.0       | None (unstable)           |
 
 ### `timestamps_iso8601`
 
@@ -201,7 +201,8 @@ and this option may be removed in a future version of the service.
 
 Sync Streams support scalar SQL operators (like `+`, `-` and `||`) and [functions](/sync/supported-sql#functions).
 SQL in Sync Streams should behave exactly as it would in SQLite, but the Service uses a custom implementation which differs
-from SQLite for some inputs.
+from SQLite for some edge cases.
 
 To perfectly align the behavior of the Service and SQLite, enabling this option makes the Service use an actual
 SQLite database to evaluate Sync Streams.
+For example, the expression `NOT NULL` evaluates to `TRUE` without this option, enabling it yields `NULL`.

--- a/sync/advanced/compatibility.mdx
+++ b/sync/advanced/compatibility.mdx
@@ -196,7 +196,7 @@ With this fix applied:
 
 <Danger>
 This option is experimental: When enabled, updates to the PowerSync Service might change how rows are processed
-and this option may be removed in a future version of the service.
+and this option may be removed in a future version of the Service.
 </Danger>
 
 Sync Streams support scalar SQL operators (like `+`, `-` and `||`) and [functions](/sync/supported-sql#functions).

--- a/sync/advanced/compatibility.mdx
+++ b/sync/advanced/compatibility.mdx
@@ -99,6 +99,7 @@ This table lists all fixes currently supported:
 | `versioned_bucket_ids`     | [Link](#versioned-bucket-ids)      | 1.15.0       | 2                |
 | `fixed_json_extract`       | [Link](#fixed-json-extract)        | 1.15.0       | 2                |
 | `custom_postgres_types`    | [Link](#custom-postgres-types).    | 1.15.3       | 2                |
+| `unstable_sqlite_expression_engine`    | [Link](#custom-postgres-types).    | 1.22.0       | None (unstable)           |
 
 ### `timestamps_iso8601`
 
@@ -190,3 +191,17 @@ With this fix applied:
     | 'empty';
   ```
 - Multi-ranges sync as an array of ranges.
+
+### `unstable_sqlite_expression_engine`
+
+<Danger>
+This option is experimental: When enabled, updates to the PowerSync Service might change how rows are processed
+and this option may be removed in a future version of the service.
+</Danger>
+
+Sync Streams support scalar SQL operators (like `+`, `-` and `||`) and [functions](/sync/supported-sql#functions).
+SQL in Sync Streams should behave exactly as it would in SQLite, but the Service uses a custom implementation which differs
+from SQLite for some inputs.
+
+To perfectly align the behavior of the Service and SQLite, enabling this option makes the Service use an actual
+SQLite database to evaluate Sync Streams.

--- a/sync/advanced/compatibility.mdx
+++ b/sync/advanced/compatibility.mdx
@@ -205,4 +205,8 @@ from SQLite for some edge cases.
 
 To perfectly align the behavior of the Service and SQLite, enabling this option makes the Service use an actual
 SQLite database to evaluate Sync Streams.
-For example, the expression `NOT NULL` evaluates to `TRUE` without this option, enabling it yields `NULL`.
+Some known issues with the JavaScript evaluator that are fixed by this option are:
+
+- Exact null handling: `NOT NULL` evaluates to `TRUE` without this option, enabling it yields `NULL`.
+- Without this option, `substr()` and `length()` operate on UTF-16 code units. Enabling it makes them operate on
+  Unicode code points.


### PR DESCRIPTION
This documents changes from https://github.com/powersync-ja/powersync-service/pull/654, released as part of version 1.22.0 of the Service.

Closes https://github.com/powersync-ja/powersync-docs/issues/479.