### PR TITLE
Update data synced FAQ wording

### DIFF
--- a/resources/usage-and-billing/usage-and-billing-faq.mdx
+++ b/resources/usage-and-billing/usage-and-billing-faq.mdx
@@ -53,7 +53,7 @@ description: "Troubleshoot usage and billing issues and find answers to common q
   <Accordion title="What is data synced?">
     Data synced is the only metric used for data throughput billing in our [updated Cloud pricing model](https://www.powersync.com/blog/simplified-cloud-pricing-based-on-data-synced).
 
-    It measures the total uncompressed size of data synced from PowerSync Service instances to client devices. If the same data is synced by multiple users, each transfer counts toward the total.
+    It measures the total uncompressed size of data synced from PowerSync Service instances to client devices. If multiple users sync the same data, each transfer counts toward the total.
     
     **Billing (Pro/Team)**: 30 GB included, then $1.00 per GB over the included amount.
   </Accordion>


### PR DESCRIPTION
Reword the data synced FAQ entry in the usage & billing FAQ from passive to active voice for clarity:

- Before: "If the same data is synced by multiple users, each transfer counts toward the total."
- After: "If multiple users sync the same data, each transfer counts toward the total."

## AI disclosure

This wording change was implemented with the assistance of Claude Code. I reviewed manually.