### PR TITLE
GRDB: Don't mention outdated session hack

### DIFF
--- a/client-sdks/orms/swift/grdb.mdx
+++ b/client-sdks/orms/swift/grdb.mdx
@@ -15,7 +15,6 @@ There are some limitations to be aware of:
 
 - Updating the PowerSync schema using `updateSchema` is not yet supported. 
 - Xcode previews may not yet work correctly. 
-- The current implementation uses the SQLite session API for change tracking, which may consume more memory than the standard PowerSync implementation. A more efficient tracking mechanism is planned.
 - You may see thread priority inversion warnings in Xcode. We're working to ensure consistent quality-of-service classes across threads.
 - The schema definition process requires manually defining both the PowerSync `AppSchema` and GRDB record types separately. Future versions may allow these to be declared together or derived from each other.
 </Note>


### PR DESCRIPTION
Starting from version 1.14.0 of the Swift SDK, we actually use our own update notifications instead of the session API. This removes the outdated note.

With the upcoming 1.14.1 release, we can use the update mechanism builtin to GRDB itself. That is an internal change though, not worth documenting.

Closes https://github.com/powersync-ja/powersync-docs/issues/489.