### PR TITLE
Document negative search filters for instance logs

### DIFF
--- a/maintenance-ops/monitoring-and-alerting.mdx
+++ b/maintenance-ops/monitoring-and-alerting.mdx
@@ -174,6 +174,23 @@ lag:>=5
 
 Only one numeric comparison is allowed per property. Combining `lag:>5 lag:<10` is rejected.
 
+#### Excluding Results
+
+Prefix a term or filter with `-` to exclude matching entries. This is useful for hiding known-noisy errors while triaging:
+
+```
+-error:PSYNC_S2106
+```
+
+Exclusion works with both syntaxes:
+
+* `-alias:value` hides entries where the property matches the value. Repeating a negated alias hides every listed value: `-user_id:123 -user_id:456` hides both users.
+* `-word` hides entries containing the text anywhere in the entry. Quote phrases: `-"token expired"`.
+
+Only an unquoted `-` at the start of a term excludes. A hyphen inside a term matches literally (`powersync-js`), and quoting keeps a leading hyphen literal: `"-foo"` finds entries containing `-foo` rather than excluding `foo`.
+
+Numeric comparisons **cannot** be negated. You should use the inverse comparison instead: `lag:<5` rather than `-lag:>=5`.
+
 #### Filtering on Other Properties
 
 The **Property filters** button in the toolbar lists the aliases for the active log type. Log entries can contain many additional properties, and you can filter on any of them using `alias:value` syntax directly in the search bar. For example:
@@ -191,13 +208,13 @@ This is the quickest way to filter on properties you spot in the logs without re
 
 #### Combined Example
 
-You can mix free-text terms, known aliases, and unknown properties in a single query:
+You can mix free-text terms, known aliases, unknown properties, and exclusions in a single query:
 
 ```
-checkpoint sync user_id:123 checkpoint:>=1224
+checkpoint sync user_id:123 checkpoint:>=1224 -error:PSYNC_S2106
 ```
 
-This matches entries containing both `checkpoint` and `sync` in the message, with `user_id` equal to `123` and a `checkpoint` property greater than or equal to `1224`.
+This matches entries containing both `checkpoint` and `sync` in the message, with `user_id` equal to `123` and a `checkpoint` property greater than or equal to `1224`, excluding entries with error code `PSYNC_S2106`.
 
 ### Export Logs
 

--- a/maintenance-ops/monitoring-and-alerting.mdx
+++ b/maintenance-ops/monitoring-and-alerting.mdx
@@ -106,9 +106,11 @@ You can manage logs with the following options:
 
 * **Log Type**: Switch between **Sync & API logs** (from the PowerSync Service API container, which handles streaming sync connections as well as other API calls) and **Replication logs**.
 * **Log Levels**: Show or hide `Info`, `Error`, `Warn`, and `Debug` entries.
-* **Time Range**: Limit results to a relative window (last 15 minutes, last hour, etc.) or a custom range. The available window depends on your plan's retention period.
+* **Time Range**: Limit results to a relative window (last 15 minutes, last hour, etc.) or a custom range. The available window depends on your plan's retention period. You can also click the timestamp on any log entry to set it as the start or end of the time range.
 * **Sort Order**: Sort by newest or oldest first.
 * **Display Options**: Show metadata pills on each entry, show stack traces for errors, and tail logs in real time.
+
+Hover over a log entry to reveal a button that copies the full log event as JSON.
 
 ### Search and Filter Logs
 


### PR DESCRIPTION
Documents the new `-` exclusion syntax in log search.

- new "Excluding Results" section under "Search and Filter Logs": `-error:PSYNC_S2106`, `-"token expired"`, literal hyphen rules, and why numeric comparisons can't be negated
- combined example now includes an exclusion

Also covers:
- Clicking a log entry's timestamp to set it as the start or end of the time range (added to the Time Range bullet)
- Hovering a log entry to copy the full log event as JSON
