### PR TITLE
Document SQLCipher for Dart

### DIFF
--- a/client-sdks/advanced/data-encryption.mdx
+++ b/client-sdks/advanced/data-encryption.mdx
@@ -13,8 +13,10 @@ The client-side database can be encrypted at rest. This is currently available f
 
 <Accordion title="Dart/Flutter" icon="flutter">
 
-The PowerSync SDK supports [SQLite3MultipleCiphers](https://utelle.github.io/SQLite3MultipleCiphers)
-on all native platforms and the web, which can be used to encrypt databases.
+The PowerSync Dart SDK provides multiple options for client-side encryption:
+
+1. [SQLite3MultipleCiphers](https://utelle.github.io/SQLite3MultipleCiphers), which is available both on native platforms and the web.
+2. [SQLCipher Community Edition](https://www.zetetic.net/sqlcipher/), available on native platforms only.
 
 <Note>Setting up encryption has changed in version 2.0 of the PowerSync SDK. When upgrading, follow these steps and remove dependencies on `powersync_sqlcipher`.</Note>
 
@@ -38,10 +40,18 @@ hooks:
   user_defines:
     sqlite3:
       # Bundle and load SQLite3MultipleCiphers instead of SQLite for encryption.
-      source: sqlite3mc
+      source: sqlite3mc # alternatively, pass sqlcipher instead.
 ```
 
-<Warning>If you're using [pub workspaces](https://dart.dev/tools/pub/workspaces), this needs to be added to the root `pubspec.yaml`, not the one for your app.</Warning>
+<Warning>
+If you're using [pub workspaces](https://dart.dev/tools/pub/workspaces), this needs to be added to the root `pubspec.yaml`, not the one for your app.
+
+Not sure whether to use SQLCipher or SQLite3MultipleCiphers? Consider this:
+
+1. SQLite3MultipleCiphers is the only option on the web, using it for native targets ensures consistency.
+2. SQLCipher can be more performant because it links OpenSSL / `Security.framework` on Apple targets instead of using a builtin implementation.
+   Using operating system libraries also makes it easier to comply with [export regulations](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations).
+</Warning>
 
 On the web, enabling encryption requires SQLite3MultipleCiphers as well. [PowerSync releases](https://github.com/powersync-ja/powersync.dart/releases)
 have a `sqlite3mc.wasm` file attached to them, which can be downloaded to `web/sqlite3.wasm` to add encryption


### PR DESCRIPTION
`sqlcipher` is available for the Dart SDK again, this documents the option and provides guidance on when it makes sense over SQLite3MultipleCiphers.

Closes https://github.com/powersync-ja/powersync-docs/issues/512.