### PR TITLE
For queries with `*` and other columns, put `*` first

### DIFF
--- a/intro/setup-guide.mdx
+++ b/intro/setup-guide.mdx
@@ -516,8 +516,8 @@ streams:
     auto_subscribe: true
     # MongoDB uses "_id" but PowerSync uses "id" on the client
     queries:
-      - SELECT _id as id, * FROM lists
-      - SELECT _id as id, * FROM todos WHERE archived = false
+      - SELECT *, _id as id FROM lists
+      - SELECT *, _id as id FROM todos WHERE archived = false
 ```
 
 ```yaml MySQL Example

--- a/sync/advanced/client-id.mdx
+++ b/sync/advanced/client-id.mdx
@@ -22,7 +22,7 @@ Custom transformations can also be used for the ID column. This is useful in cer
 
 ```sql
 -- Concatenate multiple columns into a single id column
-SELECT item_id || '.' || category_id as id, * FROM item_categories
+SELECT *, item_id || '.' || category_id as id FROM item_categories
 
 -- the source database schema for the above example is CREATE TABLE item_categories(item_id uuid, category_id uuid, PRIMARY KEY(item_id, category_id));
 ```

--- a/sync/advanced/client-id.mdx
+++ b/sync/advanced/client-id.mdx
@@ -28,6 +28,8 @@ SELECT *, item_id || '.' || category_id as id FROM item_categories
 ```
 
 <Warning>
+    For multiple columns with the same name (e.g. if there was an `id` column in `*`), the last column wins. Prefer writing the `*` before other columns for this reason.
+
     If you want to upload data to a table with a custom record ID, ensure that `uploadData()` isn't blindly using a field named `id` when handling CRUD operations. See the [Sequential ID mapping tutorial](/client-sdks/advanced/sequential-id-mapping#update-client-to-use-uuids) for an example where the record ID is aliased to `uuid` on the backend.
 </Warning>
 

--- a/sync/streams/overview.mdx
+++ b/sync/streams/overview.mdx
@@ -270,7 +270,7 @@ const sub = await db.syncStream('todos', { list_id: 'abc' })
 
 - **Type Conversion**: Data types from your source database (Postgres, MongoDB, MySQL, SQL Server or Convex) are converted when synced to the client's SQLite database. SQLite has a limited type system, so most types become `text` and you may need to parse or cast values in your app code. See [Type Mapping](/sync/types) for details on how each type is handled.
 
-- **Primary Key**: PowerSync requires every synced table to have a primary key column named `id` of type `text`. If your backend uses a different column name or type, you'll need to map it. For MongoDB, collections use `_id` as the ID field; you must alias it in your stream queries (e.g. `SELECT _id as id, * FROM your_collection`).
+- **Primary Key**: PowerSync requires every synced table to have a primary key column named `id` of type `text`. If your backend uses a different column name or type, you'll need to map it. For MongoDB, collections use `_id` as the ID field; you must alias it in your stream queries (e.g. `SELECT *, _id as id FROM your_collection`).
 
 - **Case Sensitivity**: To avoid issues across different databases and platforms, use **lowercase identifiers** for all table and column names in your Sync Streams. If your backend uses mixed case, see [Case Sensitivity](/sync/advanced/case-sensitivity) for how to handle it.
 


### PR DESCRIPTION
When a query contains multiple columns with the same name, the last column "wins" in Sync Streams and defines the value being synced for that key.

For a query like `SELECT public_id as id, * FROM ...`, the intention may be to use the `public_id` column as an id and hide the real id. Unfortunately, if the row being synced has an `id` column, then it's part of the `*` which comes last and wins against the original alias. So, our recommendation should be to put `*` first, ensuring other columns aren't ignored.

AI use: I found the examples with a regular expression, the best kind of language model. I let Claude scan for additional queries I might have missed, it found none.