### PR TITLE
Removed Maximum call stack size exceeded - safari related warnings in documentation

### DIFF
--- a/client-sdks/reference/javascript-web.mdx
+++ b/client-sdks/reference/javascript-web.mdx
@@ -388,8 +388,6 @@ This SDK supports multiple Virtual File Systems (VFS), each responsible for stor
 
 The default VFS for applications needing the broadest browser compatibility. This system utilizes IndexedDB as its underlying storage mechanism. Multiple tabs are fully supported across most modern browsers, and no additional configuration is needed.
 
-Users may experience stability issues when using Safari. For example, the `RangeError: Maximum call stack size exceeded` error. See [Troubleshooting](/debugging/troubleshooting#rangeerror-maximum-call-stack-size-exceeded-on-ios-or-safari) for more details.
-
 #### 2. OPFS-based Alternatives
 
 PowerSync supports three OPFS (Origin Private File System) implementations that generally offer improved performance compared to IndexedDB:
@@ -510,7 +508,6 @@ async function listVfsEntries() {
 <Warning>
   * Multiple tab support is not currently available on Android. 
   * For Safari, use the [`OPFSCoopSyncVFS`](/client-sdks/reference/javascript-web#sqlite-virtual-file-systems) virtual file system to ensure stable multi-tab functionality.
-  * If you encounter a `RangeError: Maximum call stack size exceeded` error, see [Troubleshooting](/debugging/troubleshooting#rangeerror-maximum-call-stack-size-exceeded-on-ios-or-safari) for solutions.
 </Warning>
 
 Using PowerSync between multiple tabs is supported on some web browsers. Multiple tab support relies on shared web workers for database and sync streaming operations. When enabled, shared web workers named `shared-DB-worker-[dbFileName]` and `shared-sync-[dbFileName]` will be created.

--- a/debugging/troubleshooting.mdx
+++ b/debugging/troubleshooting.mdx
@@ -13,46 +13,6 @@ description: "Diagnose and fix common PowerSync issues using logs, diagnostics, 
 
 This client-side error or similar typically occurs when PowerSync is used in conjunction with either another SQLite library or the standard system SQLite library. PowerSync is generally not compatible with multiple SQLite sources. If another SQLite library exists in your project dependencies, remove it if it is not required. In some cases, there might be other workarounds. For example, in Flutter projects, we've seen this issue with `sqflite 2.2.6`, but `sqflite 2.3.3+1` does not throw the same exception.
 
-### `RangeError: Maximum call stack size exceeded` on iOS or Safari
-
-This client-side error commonly occurs when using the PowerSync Web SDK on Safari or iOS (including iOS simulator).
-
-**Solutions:**
-
-1. **Use OPFSCoopSyncVFS (Recommended)**: Switch to the `OPFSCoopSyncVFS` virtual file system, which provides better Safari compatibility and multi-tab support:
-
-```js
-import { PowerSyncDatabase, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web';
-
-export const db = new PowerSyncDatabase({
-  schema: AppSchema,
-  database: new WASQLiteOpenFactory({
-    dbFilename: 'exampleVFS.db',
-    vfs: WASQLiteVFS.OPFSCoopSyncVFS,
-    flags: {
-      enableMultiTabs: typeof SharedWorker !== 'undefined'
-    }
-  }),
-  flags: {
-    enableMultiTabs: typeof SharedWorker !== 'undefined'
-  }
-});
-```
-
-2. **Disable Web Workers (Alternative)**: Set the `useWebWorker` flag to `false`, but note that this disables multi-tab support:
-
-```js
-export const db = new PowerSyncDatabase({
-  schema: AppSchema,
-  database: {
-    dbFilename: 'powersync.db'
-  },
-  flags: {
-    useWebWorker: false
-  }
-});
-```
-
 ### Too Many Buckets (`PSYNC_S2305`)
 
 PowerSync uses internal partitions called [buckets](/architecture/powersync-service#bucket-system) to organize and sync data efficiently. There is a [default limit of 1,000 buckets](/resources/performance-and-limits) per user/client. When this limit is exceeded, you will see a `PSYNC_S2305` error in your Sync & API logs.


### PR DESCRIPTION
After the investigation in this [internal doc](https://docs.google.com/document/d/1I0v2rofS-0OvnaxfLAfp1_NS0m4TJo97OaCIuHfnF70/edit?tab=t.0) and the report [here](https://github.com/rhashimoto/wa-sqlite/discussions/243#discussioncomment-12690676), these warnings about IndexedDB in Safari are no longer relevant.