### PR TITLE
Document changes for upcoming 1.15 Swift SDK

### DIFF
--- a/client-sdks/reference/swift.mdx
+++ b/client-sdks/reference/swift.mdx
@@ -284,7 +284,9 @@ between multiple apps in an app group, provide an absolute path (starting with `
 `PowerSyncDatabase`.
 The path should point towards a file in the app group's [shared container](https://developer.apple.com/documentation/xcode/configuring-app-groups#Access-an-app-groups-shared-container).
 
-<Info>Support for app groups and extensions was added in version 1.15, and is experimental.</Info>
+<Warning>
+  Support for app groups and extensions was added in version 1.15, and is experimental.
+</Warning>
 
 With app groups and extensions, multiple processes might access the database at the same time. SQLite uses shared memory
 and file locking to make this safe, but there are still concerns that aren't relevant when the database is only accessed

--- a/client-sdks/reference/swift.mdx
+++ b/client-sdks/reference/swift.mdx
@@ -277,6 +277,33 @@ let db = PowerSyncDatabase(
 
 The `DefaultLogger` supports the following severity levels: `.debug`, `.info`, `.warn`, `.error`. 
 
+## App Groups and App Extensions
+
+By default, the Swift SDK stores databases in `applicationSupportDirectory`. If you want to share local databases
+between multiple apps in an app group, provide an absolute path (starting with `/`) as `dbFilename` when calling
+`PowerSyncDatabase`.
+The path should point towards a file in the app group's [shared container](https://developer.apple.com/documentation/xcode/configuring-app-groups#Access-an-app-groups-shared-container).
+
+<Info>Support for app groups and extensions was added in version 1.15, and is experimental.</Info>
+
+With app groups and extensions, multiple processes might access the database at the same time. SQLite uses shared memory
+and file locking to make this safe, but there are still concerns that aren't relevant when the database is only accessed
+from a single context:
+
+1. Concurrent writes to the database are not allowed. Within a process, the PowerSync SDK uses Swift actors to schedule
+   writes. Outside of SQLite using file locks, there is no additional coordination for multi-process access.
+  - Consider using [`PRAGMA busy_timeout`](https://sqlite.org/pragma.html#pragma_busy_timeout) to make SQLite wait longer.
+  - Be ready to handle `SQLITE_BUSY` errors if multiple processes attempt to write to the database.
+2. Do not call `connect()` in more than one process! If two processes attempt to connect to the PowerSync service for
+   the same database, this wastes resources and can also lead to concurrency issues. If you share databases with extensions
+   or app groups, ensure there is only context responsible for connecting.
+3. Avoid multiple versions of the Swift SDK: While the SQLite file format is stable and databases can safely be accessed
+   from multiple processes using their own SQLite version, the PowerSync SDK is not designed with this in mind.
+   In particular, opening the same database file from multiple processes can cause PowerSync-internal migrations to get
+   reverted.
+   This is not a concern for app extensions released as part of the same bundle, but something to be aware of for
+   app groups.
+
 ## Additional Usage Examples
 
 For more usage examples including accessing connection status, monitoring sync progress, and waiting for initial sync, see the [Usage Examples](/client-sdks/usage-examples) page.

--- a/client-sdks/reference/swift.mdx
+++ b/client-sdks/reference/swift.mdx
@@ -292,11 +292,11 @@ from a single context:
 
 1. Concurrent writes to the database are not allowed. Within a process, the PowerSync SDK uses Swift actors to schedule
    writes. Outside of SQLite using file locks, there is no additional coordination for multi-process access.
-  - Consider using [`PRAGMA busy_timeout`](https://sqlite.org/pragma.html#pragma_busy_timeout) to make SQLite wait longer.
-  - Be ready to handle `SQLITE_BUSY` errors if multiple processes attempt to write to the database.
-2. Do not call `connect()` in more than one process! If two processes attempt to connect to the PowerSync service for
+    - Consider using [`PRAGMA busy_timeout`](https://sqlite.org/pragma.html#pragma_busy_timeout) to make SQLite wait longer.
+    - Be ready to handle `SQLITE_BUSY` errors if multiple processes attempt to write to the database.
+2. Do not call `connect()` in more than one process: If two processes attempt to connect to the PowerSync service for
    the same database, this wastes resources and can also lead to concurrency issues. If you share databases with extensions
-   or app groups, ensure there is only context responsible for connecting.
+   or app groups, ensure there is only one context responsible for connecting.
 3. Avoid multiple versions of the Swift SDK: While the SQLite file format is stable and databases can safely be accessed
    from multiple processes using their own SQLite version, the PowerSync SDK is not designed with this in mind.
    In particular, opening the same database file from multiple processes can cause PowerSync-internal migrations to get

--- a/client-sdks/usage-examples.mdx
+++ b/client-sdks/usage-examples.mdx
@@ -879,26 +879,19 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		import PowerSync
 
 		struct PowerSyncConnectionIndicator: View {
-		    private let powersync: any PowerSyncDatabaseProtocol
-		    @State private var connected: Bool = false
+		    private let status: ObservableSyncStatus
 		    
 		    init(powersync: any PowerSyncDatabaseProtocol) {
-		        self.powersync = powersync
+		        self.status = powersync.currentStatus.observable
 		    }
 		    
 		    var body: some View {
+				let connected = status.connected
 		        let iconName = connected ? "wifi" : "wifi.slash"
 		        let description = connected ? "Online" : "Offline"
 		        
 		        Image(systemName: iconName)
 		            .accessibility(label: Text(description))
-		            .task {
-		                self.connected = powersync.currentStatus.connected
-		                
-		                for await status in powersync.currentStatus.asFlow() {
-		                    self.connected = status.connected
-		                }
-		           }
 		    }
 		}
 		```

--- a/client-sdks/usage-examples.mdx
+++ b/client-sdks/usage-examples.mdx
@@ -1391,12 +1391,11 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 
 		```swift
 		struct SyncProgressIndicator: View {
-		    private let powersync: any PowerSyncDatabaseProtocol
+		    private let status: ObservableSyncStatus
 		    private let priority: BucketPriority?
-		    @State private var status: SyncStatusData? = nil
 
 		    init(powersync: any PowerSyncDatabaseProtocol, priority: BucketPriority? = nil) {
-		        self.powersync = powersync
+		        self.status = powersync.currentStatus.observable
 		        self.priority = priority
 		    }
 		    
@@ -1416,11 +1415,6 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		                } else {
 		                    Text("Downloaded \(progress.downloadedOperations) out of \(progress.totalOperations)")
 		                }
-		            }
-		        }.task {
-		            status = powersync.currentStatus
-		            for await status in powersync.currentStatus.asFlow() {
-		                self.status = status
 		            }
 		        }
 		    }

--- a/client-sdks/usage-examples.mdx
+++ b/client-sdks/usage-examples.mdx
@@ -886,7 +886,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		    }
 		    
 		    var body: some View {
-				let connected = status.connected
+		        let connected = status.connected
 		        let iconName = connected ? "wifi" : "wifi.slash"
 		        let description = connected ? "Online" : "Offline"
 		        

--- a/client-sdks/usage-examples.mdx
+++ b/client-sdks/usage-examples.mdx
@@ -1394,7 +1394,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		    
 		    var body: some View {
 		        VStack {
-		            if let totalProgress = status?.downloadProgress {
+		            if let totalProgress = status.downloadProgress {
 		                let progress = if let priority = self.priority {
 		                    totalProgress.untilPriority(priority: priority)
 		                } else {


### PR DESCRIPTION
This adds documentation for pending Swift SDK changes:

- Support for absolute paths to share databases across app extensions and app groups.
- The `ObservableSyncStatus` API to observe sync status changes from SwiftUI views more easily.

A new feature not documented here is the ability to add custom HTTP headers. I'll open a separate docs PR for that, since we should document that for all our SDKs.

AI use: I used Claude Code to check these changes against a Swift SDK diff. All documentation updates are written by hand.

Closes https://github.com/powersync-ja/powersync-docs/issues/527.