### PR TITLE
Document community Swift Data integration

### DIFF
--- a/client-sdks/reference/swift.mdx
+++ b/client-sdks/reference/swift.mdx
@@ -283,7 +283,11 @@ For more usage examples including accessing connection status, monitoring sync p
 
 ## ORM Support
 
-PowerSync supports the [GRDB](/client-sdks/orms/swift/grdb) library for Swift.
+PowerSync officially supports the [GRDB](/client-sdks/orms/swift/grdb) library for Swift.
+
+Additionally, [Asier G. Morato](https://github.com/asiergmorato) contributed a [Swift Data integration](https://github.com/powersync-community/swift-data)
+for PowerSync, allowing Swift Data models to be persisted and synced through a PowerSync database.
+Note that the integration is community-owned and not officially supported by PowerSync.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This mentions the powersync-community [Swift Data integration](github.com/powersync-community/swift-data) contributed by @asiergmorato.

The readme of that repository contains usage instructions, so given that it's not an official integration I don't think we need to put it on a separate page like GRDB.