### PR TITLE
Fix JavaScript doc links

### DIFF
--- a/client-sdks/reference/capacitor.mdx
+++ b/client-sdks/reference/capacitor.mdx
@@ -164,7 +164,7 @@ const db = new PowerSyncDatabase({
 });
 ```
 
-Once you've instantiated your PowerSync database, call the [connect()](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#connect) method to sync data with your backend.
+Once you've instantiated your PowerSync database, call the [connect()](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#connect) method to sync data with your backend.
 
 <LocalOnly />
 
@@ -234,7 +234,7 @@ The most commonly used CRUD functions to interact with your SQLite data are:
 
 ### Fetching a Single Item
 
-The [get](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#get) method executes a read-only (SELECT) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
+The [get](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#get) method executes a read-only (SELECT) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
 
 ```js
 // Find a list item by ID
@@ -246,7 +246,7 @@ export const findList = async (id) => {
 
 ### Querying Items (PowerSync.getAll)
 
-The [getAll](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#getall) method returns a set of rows from a table.
+The [getAll](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getall) method returns a set of rows from a table.
 
 ```js
 // Get all list IDs
@@ -258,7 +258,7 @@ export const getLists = async () => {
 
 ### Watching Queries (PowerSync.watch)
 
-The [watch](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made.
+The [watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made.
 
 <Tabs>
   <Tab title="AsyncIterator approach">
@@ -273,7 +273,7 @@ For advanced watch query features like incremental updates and differential resu
 
 ### Mutations (PowerSync.execute, PowerSync.writeTransaction)
 
-The [execute](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
+The [execute](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
 
 ```js
 // Delete a list item by ID

--- a/client-sdks/reference/javascript-web.mdx
+++ b/client-sdks/reference/javascript-web.mdx
@@ -163,13 +163,7 @@ export const db = new PowerSyncDatabase({
 });
 ```
 
-<Note>
-  **SDK versions lower than 1.2.0**
-
-  In SDK versions lower than 1.2.0, you will need to use the deprecated [WASQLitePowerSyncDatabaseOpenFactory](https://powersync-ja.github.io/powersync-js/web-sdk/classes/WASQLitePowerSyncDatabaseOpenFactory) syntax to instantiate the database.
-</Note>
-
-Once you've instantiated your PowerSync database, call the [connect()](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#connect) method to sync data with your backend.
+Once you've instantiated your PowerSync database, call the [connect()](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#connect) method to sync data with your backend.
 
 <LocalOnly />
 
@@ -231,7 +225,7 @@ The most commonly used CRUD functions to interact with your SQLite data are:
 
 ### Fetching a Single Item
 
-The [get](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#get) method executes a read-only (SELECT) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
+The [get](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#get) method executes a read-only (SELECT) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
 
 ```js
 // Find a list item by ID
@@ -243,7 +237,7 @@ export const findList = async (id) => {
 
 ### Querying Items (PowerSync.getAll)
 
-The [getAll](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#getall) method returns a set of rows from a table.
+The [getAll](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getall) method returns a set of rows from a table.
 
 ```js
 // Get all list IDs
@@ -255,7 +249,7 @@ export const getLists = async () => {
 
 ### Watching Queries (PowerSync.watch)
 
-The [watch](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made.
+The [watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made.
 
 <Tabs>
   <Tab title="AsyncIterator approach">
@@ -270,7 +264,7 @@ For advanced watch query features like incremental updates and differential resu
 
 ### Mutations (PowerSync.execute, PowerSync.writeTransaction)
 
-The [execute](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
+The [execute](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
 
 ```js
 // Delete a list item by ID
@@ -320,7 +314,7 @@ const logger = createConsoleLogger({ minLevel: LogLevels.trace });
   ```
 </Tip>
 
-Additionally, the [WASQLiteDBAdapter](https://powersync-ja.github.io/powersync-js/web-sdk/classes/WASQLiteDBAdapter) opens SQLite connections inside a shared web worker. This worker can be inspected in Chrome by accessing:
+Additionally, the [WASQLiteOpenFactory](https://powersync-ja.github.io/powersync-js/web-sdk/classes/WASQLiteOpenFactory) opens SQLite connections inside a shared web worker. This worker can be inspected in Chrome by accessing:
 
 ```
 chrome://inspect/#workers

--- a/client-sdks/reference/react-native-and-expo.mdx
+++ b/client-sdks/reference/react-native-and-expo.mdx
@@ -125,7 +125,7 @@ export const powersync = new PowerSyncDatabase({
 });
 ```
 
-Once you've instantiated your PowerSync database, call the [connect()](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#connect) method to sync data with your backend.
+Once you've instantiated your PowerSync database, call the [connect()](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#connect) method to sync data with your backend.
 
 <LocalOnly />
 
@@ -182,7 +182,7 @@ export class Connector implements PowerSyncBackendConnector {
 
     /**
     * For batched crud transactions, use data.getCrudBatch(n);
-    * https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SqliteBucketStorage#getcrudbatch
+    * https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getcrudbatch
     */
     const transaction = await database.getNextCrudTransaction();
 
@@ -225,7 +225,7 @@ The most commonly used CRUD functions to interact with your SQLite data are:
 
 ### Fetching a Single Item
 
-The [get](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#get) method executes a read-only (`SELECT`) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
+The [get](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#get) method executes a read-only (`SELECT`) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
 
 
 ```js TodoItemWidget.jsx
@@ -249,7 +249,7 @@ export const TodoItemWidget = ({id}) => {
 
 ### Querying Items (`PowerSync.getAll`)
 
-The [getAll](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#getall) method returns a set of rows from a table.
+The [getAll](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getall) method returns a set of rows from a table.
 
 ```js ListsWidget.jsx
 import { FlatList, Text} from 'react-native';
@@ -271,7 +271,7 @@ export const ListsWidget = () => {
 
 ### Watching Queries (`PowerSync.watch`)
 
-The [watch](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made. It can be used with an `AsyncGenerator`, or with a callback.
+The [watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made. It can be used with an `AsyncGenerator`, or with a callback.
 
 <Tabs>
   <Tab title="AsyncIterator approach">
@@ -286,7 +286,7 @@ For advanced watch query features like incremental updates and differential resu
 
 ### Mutations (`PowerSync.execute`)
 
-The [execute](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
+The [execute](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
 
 ```js ListsWidget.jsx
 import { Alert, Button, FlatList, Text, View } from 'react-native';

--- a/client-sdks/reference/tauri.mdx
+++ b/client-sdks/reference/tauri.mdx
@@ -244,7 +244,7 @@ The most commonly used CRUD functions to interact with your SQLite data are:
 
 ### Fetching a Single Item
 
-The [get](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#get) method executes a read-only (SELECT) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
+The [get](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#get) method executes a read-only (SELECT) query and returns a single result. It throws an exception if no result is found. Use [getOptional](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getoptional) to return a single optional result (returns `null` if no result is found).
 
 ```js
 // Find a list item by ID
@@ -256,7 +256,7 @@ export const findList = async (id) => {
 
 ### Querying Items (PowerSync.getAll)
 
-The [getAll](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#getall) method returns a set of rows from a table.
+The [getAll](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#getall) method returns a set of rows from a table.
 
 ```js
 // Get all list IDs
@@ -268,7 +268,7 @@ export const getLists = async () => {
 
 ### Watching Queries (PowerSync.watch)
 
-The [watch](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made.
+The [watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) method executes a read query whenever a change to a dependent table is made.
 
 <Tabs>
   <Tab title="AsyncIterator approach">
@@ -283,7 +283,7 @@ For advanced watch query features like incremental updates and differential resu
 
 ### Mutations (PowerSync.execute, PowerSync.writeTransaction)
 
-The [execute](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
+The [execute](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#execute) method can be used for executing single SQLite write statements.
 
 ```js
 // Delete a list item by ID

--- a/client-sdks/usage-examples.mdx
+++ b/client-sdks/usage-examples.mdx
@@ -36,7 +36,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       <Tab title="React Native & Expo">
 		Read and write transactions present a context where multiple changes can be made then finally committed to the DB or rolled back. This ensures that either all the changes get persisted, or no change is made to the DB (in the case of a rollback or exception).
 
-		[PowerSyncDatabase.writeTransaction(callback)](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#writetransaction) automatically commits changes after the transaction callback is completed if [`tx.rollback()`](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/db/DBAdapter.ts#L53) has not explicitly been called. If an exception is thrown in the callback then changes are automatically rolled back.
+		[PowerSyncDatabase.writeTransaction(callback)](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#writetransaction) automatically commits changes after the transaction callback is completed if [`tx.rollback()`](https://github.com/powersync-ja/powersync-js/blob/ed5bb49b5a1dc579050304fab847feb8d09b45c7/packages/common/src/db/DBAdapter.ts#L53) has not explicitly been called. If an exception is thrown in the callback then changes are automatically rolled back.
 
 
 		```js
@@ -94,13 +94,13 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		}
 		```
 
-		Also see [PowerSyncDatabase.readTransaction(callback)](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#readtransaction).
+		Also see [PowerSyncDatabase.readTransaction(callback)](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#readtransaction).
       </Tab>
 
       <Tab title="JavaScript Web">
 		Read and write transactions present a context where multiple changes can be made then finally committed to the DB or rolled back. This ensures that either all the changes get persisted, or no change is made to the DB (in the case of a rollback or exception).
 
-		[PowerSyncDatabase.writeTransaction(callback)](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#writetransaction) automatically commits changes after the transaction callback is completed if `tx.rollback()` has not explicitly been called. If an exception is thrown in the callback then changes are automatically rolled back.
+		[PowerSyncDatabase.writeTransaction(callback)](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#writetransaction) automatically commits changes after the transaction callback is completed if `tx.rollback()` has not explicitly been called. If an exception is thrown in the callback then changes are automatically rolled back.
 
 		```js
 		// ListsWidget.jsx
@@ -158,7 +158,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		};
 		```
 
-		Also see [PowerSyncDatabase.readTransaction(callback)](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#readtransaction).
+		Also see [PowerSyncDatabase.readTransaction(callback)](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#readtransaction).
       </Tab>
 
       <Tab title="Capacitor">
@@ -239,7 +239,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="React Native & Expo">
-		Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#watch) to watch for changes in source tables.
+		Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) to watch for changes in source tables.
 
 		<Tabs>
 		  <Tab title="AsyncIterator approach">
@@ -254,7 +254,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="JavaScript Web">
-		Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#watch) to watch for changes in source tables.
+		Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) to watch for changes in source tables.
 
 		<Tabs>
 		  <Tab title="AsyncIterator approach">
@@ -284,7 +284,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="Node.js">
-		Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/node-sdk/classes/PowerSyncDatabase#watch) to watch for changes in source tables.
+		Use [PowerSyncDatabase.watch](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#watch) to watch for changes in source tables.
 
 		<Tabs>
 		  <Tab title="AsyncIterator approach">
@@ -359,7 +359,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="React Native & Expo">
-		Use [PowerSyncDatabase.execute](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#execute) to run INSERT, UPDATE or DELETE queries.
+		Use [PowerSyncDatabase.execute](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#execute) to run INSERT, UPDATE or DELETE queries.
 
 		```js
 		const handleButtonClick = async () => {
@@ -379,7 +379,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="JavaScript Web">      
-		Use [PowerSyncDatabase.execute](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#execute) to run INSERT, UPDATE or DELETE queries.
+		Use [PowerSyncDatabase.execute](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#execute) to run INSERT, UPDATE or DELETE queries.
 
 		```js
 		const handleButtonClick = async () => {
@@ -778,7 +778,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="React Native & Expo">
-		Use [PowerSyncDatabase.connected](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#connected) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#registerlistener) to listen for status changes to your PowerSync instance.
+		Use [PowerSyncDatabase.connected](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#connected) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#registerlistener) to listen for status changes to your PowerSync instance.
 
 		```js
 		// Example of using connected status to show online or offline
@@ -815,7 +815,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="JavaScript Web">
-		Use [PowerSyncDatabase.connected](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#connected) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#registerlistener) to listen for status changes to your PowerSync instance.
+		Use [PowerSyncDatabase.connected](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#connected) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#registerlistener) to listen for status changes to your PowerSync instance.
 
 		```js
 		// Example of using connected status to show online or offline
@@ -1008,7 +1008,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="React Native & Expo">
-		Use the [hasSynced](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SyncStatus#hassynced) property (available since version 1.4.1 of the SDK) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#registerlistener) to indicate to the user whether the initial sync is in progress.
+		Use the [hasSynced](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus#hassynced) property (available since version 1.4.1 of the SDK) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#registerlistener) to indicate to the user whether the initial sync is in progress.
 
 		```js
 		// Example of using hasSynced to show whether the first sync has completed
@@ -1028,11 +1028,11 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		return <Text>{hasSynced ? 'Initial sync completed!' : 'Busy with initial sync...'}</Text>;
 		```
 
-		For async use cases, see [PowerSyncDatabase.waitForFirstSync](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/PowerSyncDatabase#waitforfirstsync), which returns a promise that resolves once the first full sync has completed (it queries the internal SQL [ps\_buckets](/architecture/client-architecture) table to determine if data has been synced).
+		For async use cases, see [PowerSyncDatabase.waitForFirstSync](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#waitforfirstsync), which returns a promise that resolves once the first full sync has completed (it queries the internal SQL [ps\_buckets](/architecture/client-architecture) table to determine if data has been synced).
       </Tab>
 
       <Tab title="JavaScript Web">
-		Use the [hasSynced](https://powersync-ja.github.io/powersync-js/web-sdk/classes/SyncStatus#hassynced) property (available since version 0.4.1 of the SDK) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#registerlistener) to indicate to the user whether the initial sync is in progress.
+		Use the [hasSynced](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus#hassynced) property (available since version 0.4.1 of the SDK) and register an event listener with [PowerSyncDatabase.registerListener](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#registerlistener) to indicate to the user whether the initial sync is in progress.
 
 		```js
 		// Example of using hasSynced to show whether the first sync has completed
@@ -1052,7 +1052,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		return <div>{hasSynced ? 'Initial sync completed!' : 'Busy with initial sync...'}</div>;
 		```
 
-		For async use cases, see [PowerSyncDatabase.waitForFirstSync()](https://powersync-ja.github.io/powersync-js/web-sdk/classes/PowerSyncDatabase#waitforfirstsync), which returns a promise that resolves once the first full sync has completed (it queries the internal SQL [ps\_buckets](/architecture/client-architecture) table to determine if data has been synced).
+		For async use cases, see [PowerSyncDatabase.waitForFirstSync()](https://powersync-ja.github.io/powersync-js/common/interfaces/CommonPowerSyncDatabase#waitforfirstsync), which returns a promise that resolves once the first full sync has completed (it queries the internal SQL [ps\_buckets](/architecture/client-architecture) table to determine if data has been synced).
       </Tab>
 
       <Tab title="Capacitor">
@@ -1216,7 +1216,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
       </Tab>
 
       <Tab title="React Native & Expo">
-		You can show users a progress bar when data downloads using the `downloadProgress` property from the [SyncStatus](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SyncStatus) class. This is especially useful for long-running initial syncs. `downloadProgress.downloadedFraction` gives you a value from 0.0 to 1.0 representing the total sync progress. 
+		You can show users a progress bar when data downloads using the `downloadProgress` property from the [SyncStatus](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus) class. This is especially useful for long-running initial syncs. `downloadProgress.downloadedFraction` gives you a value from 0.0 to 1.0 representing the total sync progress. 
 
 		Example:
 
@@ -1251,13 +1251,13 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		```
 
 		Also see:
-		- [SyncStatus API](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SyncStatus)
+		- [SyncStatus API](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus)
 		- [Demo component](https://github.com/powersync-ja/powersync-js/blob/main/demos/react-native-supabase-todolist/library/widgets/GuardBySync.tsx)
       </Tab>
 
       <Tab title="JavaScript Web">
 		You can show users a progress bar when data downloads using the `downloadProgress` property from the
-		[SyncStatus](https://powersync-ja.github.io/powersync-js/web-sdk/classes/SyncStatus) class. This is especially useful for long-running initial syncs. `downloadProgress.downloadedFraction` gives you a value from 0.0 to 1.0 representing the total sync progress.
+		[SyncStatus](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus) class. This is especially useful for long-running initial syncs. `downloadProgress.downloadedFraction` gives you a value from 0.0 to 1.0 representing the total sync progress.
 
 		Example (React, using [MUI](https://mui.com) components):
 
@@ -1293,7 +1293,7 @@ import JavaScriptCallbackWatch from '/snippets/basic-watch-query-javascript-call
 		```
 
 		Also see:
-		- [SyncStatus API](https://powersync-ja.github.io/powersync-js/web-sdk/classes/SyncStatus)
+		- [SyncStatus API](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus)
 		- [Demo component](https://github.com/powersync-ja/powersync-js/blob/main/demos/react-supabase-todolist/src/components/widgets/GuardBySync.tsx)
       </Tab>
 

--- a/maintenance-ops/production-readiness-guide.mdx
+++ b/maintenance-ops/production-readiness-guide.mdx
@@ -29,9 +29,7 @@ Each of the PowerSync Client SDKs have the `SyncStatus` class that can be used t
 - [Flutter](https://pub.dev/documentation/powersync/latest/powersync/SyncStatus-class.html)
 - [Kotlin](https://powersync-ja.github.io/powersync-kotlin/core/com.powersync.sync/-sync-status/index.html?query=data%20class%20SyncStatus%20:%20SyncStatusData)
 - [Swift](https://powersync-ja.github.io/powersync-swift/documentation/powersync/syncstatusdata)
-- [Web](https://powersync-ja.github.io/powersync-js/web-sdk/classes/SyncStatus)
-- [React Native](https://powersync-ja.github.io/powersync-js/react-native-sdk/classes/SyncStatus)
-- [Node.js](https://powersync-ja.github.io/powersync-js/node-sdk/classes/SyncStatus)
+- [JavaScript](https://powersync-ja.github.io/powersync-js/common/interfaces/SyncStatus) (re-exported from all SDK packages)
 - [.NET (Beta)](https://github.com/powersync-ja/powersync-dotnet/blob/2728eab0d13849686ff3f9a603040940744599e1/PowerSync/PowerSync.Common/DB/Crud/SyncStatus.cs)
 
 In addition to the `SyncStatus` options above, it's also a good idea to see what the current length of the upload queue looks like.


### PR DESCRIPTION
`PowerSyncDatabase` and `SyncStatus` used to be exported as regular classes, giving them their own documentation page.

In versions 2 of the JavaScript SDKs, we stopped doing that:

- We want to hide internal superclasses of `PowerSyncDatabase`, so we only export its public interface and a separate constructor.
- `SyncStatus` is not meant to be instantiated by users, so we only export its interface.

This breaks a few links in the documentation, this PR updates them to point to interfaces from `@powersync/common` as a canonical definition.