### PR TITLE
Remove mentions of wa-sqlite peer dependency

### DIFF
--- a/client-sdks/frameworks/next-js.mdx
+++ b/client-sdks/frameworks/next-js.mdx
@@ -61,20 +61,18 @@ In addition to this we'll also install [`@powersync/react`](https://www.npmjs.co
 <CodeGroup>
 
 ```shell npm
-npm install @powersync/web @journeyapps/wa-sqlite @powersync/react
+npm install @powersync/web @powersync/react
 ```
 
 ```shell yarn
-yarn add @powersync/web @journeyapps/wa-sqlite @powersync/react
+yarn add @powersync/web @powersync/react
 ```
 
 ```shell pnpm
-pnpm install @powersync/web @journeyapps/wa-sqlite @powersync/react
+pnpm install @powersync/web @powersync/react
 ```
 
 </CodeGroup>
-
-<Note>This SDK currently requires [@journeyapps/wa-sqlite](https://www.npmjs.com/package/@journeyapps/wa-sqlite) as a peer dependency.</Note>
 
 ### Copy Worker Assets
 

--- a/client-sdks/frameworks/tanstack.mdx
+++ b/client-sdks/frameworks/tanstack.mdx
@@ -67,17 +67,17 @@ Install the TanStackDB-PowerSync collection package with a PowerSync SDK. Then d
 <Tabs>
   <Tab title="npm">
     ```bash
-    npm install @tanstack/powersync-db-collection @powersync/web @journeyapps/wa-sqlite
+    npm install @tanstack/powersync-db-collection @powersync/web
     ```
   </Tab>
   <Tab title="yarn">
     ```bash
-    yarn add @tanstack/powersync-db-collection @powersync/web @journeyapps/wa-sqlite
+    yarn add @tanstack/powersync-db-collection @powersync/web
     ```
   </Tab>
   <Tab title="pnpm">
     ```bash
-    pnpm install @tanstack/powersync-db-collection @powersync/web @journeyapps/wa-sqlite
+    pnpm install @tanstack/powersync-db-collection @powersync/web
     ```
   </Tab>
 </Tabs>

--- a/client-sdks/reference/javascript-web.mdx
+++ b/client-sdks/reference/javascript-web.mdx
@@ -343,17 +343,17 @@ Run the below command in your project folder:
 <Tabs>
   <Tab title="npm">
 ```bash
-npm upgrade @powersync/web @journeyapps/wa-sqlite
+npm upgrade @powersync/web
 ```
   </Tab>
   <Tab title="yarn">
 ```bash
-yarn upgrade @powersync/web @journeyapps/wa-sqlite
+yarn upgrade @powersync/web
 ```
   </Tab>
   <Tab title="pnpm">
 ```bash
-pnpm upgrade @powersync/web @journeyapps/wa-sqlite
+pnpm upgrade @powersync/web
 ```
   </Tab>
 </Tabs>

--- a/snippets/capacitor/installation.mdx
+++ b/snippets/capacitor/installation.mdx
@@ -33,19 +33,19 @@ You must also install the following peer dependencies:
 <Tabs>
   <Tab title="npm">
     ```bash
-    npm install @capacitor-community/sqlite @powersync/web @journeyapps/wa-sqlite
+    npm install @capacitor-community/sqlite @powersync/web
     ```
   </Tab>
 
   <Tab title="yarn">
     ```bash
-    yarn add @capacitor-community/sqlite @powersync/web @journeyapps/wa-sqlite
+    yarn add @capacitor-community/sqlite @powersync/web
     ```
   </Tab>
 
   <Tab title="pnpm">
     ```bash
-    pnpm install @capacitor-community/sqlite @powersync/web @journeyapps/wa-sqlite
+    pnpm install @capacitor-community/sqlite @powersync/web
     ```
   </Tab>
 </Tabs>

--- a/snippets/javascript-web/installation.mdx
+++ b/snippets/javascript-web/installation.mdx
@@ -19,27 +19,3 @@ Add the [PowerSync Web NPM package](https://www.npmjs.com/package/@powersync/web
     ```
   </Tab>
 </Tabs>
-
-**Install Peer Dependencies**
-  
-This SDK currently requires [`@journeyapps/wa-sqlite`](https://www.npmjs.com/package/@journeyapps/wa-sqlite) as a peer dependency. Install it in your app with:
-  
-<Tabs>
-  <Tab title="npm">
-    ```bash
-    npm install @journeyapps/wa-sqlite
-    ```
-  </Tab>
-
-  <Tab title="yarn">
-    ```bash
-    yarn add @journeyapps/wa-sqlite
-    ```
-  </Tab>
-
-  <Tab title="pnpm">
-    ```bash
-    pnpm install @journeyapps/wa-sqlite
-    ```
-  </Tab>
-</Tabs>


### PR DESCRIPTION
With version 2.1.0 of `@powersync/web`, `@journeyapps/wa-sqlite` is no longer a peer dependency. Users won't have to install it manually anymore, this updates install commands and descriptions to reflect that.