### PR TITLE
Update .NET SQLite extension loading docs

### DIFF
--- a/client-sdks/advanced/sqlite-extensions.mdx
+++ b/client-sdks/advanced/sqlite-extensions.mdx
@@ -153,7 +153,11 @@ before opening PowerSync databases.
 
 ## .Net
 
-The PowerSync .NET SDK has builtin support for loading custom extensions. To load custom extensions, set the `MDSQLiteOptions.Extensions` field to an array of `SqliteExtension` objects. You can also disable loading the [core PowerSync SQLite extension](https://github.com/powersync-ja/powersync-sqlite-core) by setting `MDSQLiteOptions.LoadPowerSyncExtension` to false. When doing so, it is **your responsibility** to ensure that one of the extensions passed in `MDSQLiteOptions.Extensions` contains a build of the PowerSync core extension. Running the PowerSync .NET SDK without the core extension or with an outdated version of the core extension is **not supported**.
+The PowerSync .NET SDK has builtin support for loading custom extensions by setting the `MDSQLiteOptions.Extensions` field to an array of `SqliteExtension` objects.
+
+You can also disable loading the [core PowerSync SQLite extension](https://github.com/powersync-ja/powersync-sqlite-core) by setting `MDSQLiteOptions.LoadPowerSyncExtension` to false. When doing so, you must ensure that one of the extensions passed in `MDSQLiteOptions.Extensions` contains a build of the PowerSync core extension.
+
+<Warning>Running the PowerSync .NET SDK without the core extension or with an outdated version of the core extension is not supported.</Warning>
 
 It is your responsibility to build and bundle extensions you want to use with your app so that they can be loaded.
 

--- a/client-sdks/advanced/sqlite-extensions.mdx
+++ b/client-sdks/advanced/sqlite-extensions.mdx
@@ -153,7 +153,8 @@ before opening PowerSync databases.
 
 ## .Net
 
-The PowerSync .NET SDK has builtin support for loading extensions through the `MDSQLiteOptions.Extensions` field.
+The PowerSync .NET SDK has builtin support for loading custom extensions. To load custom extensions, set the `MDSQLiteOptions.Extensions` field to an array of `SqliteExtension` objects. You can also disable loading the [core PowerSync SQLite extension](https://github.com/powersync-ja/powersync-sqlite-core) by setting `MDSQLiteOptions.LoadPowerSyncExtension` to false. When doing so, it is **your responsibility** to ensure that one of the extensions passed in `MDSQLiteOptions.Extensions` contains a build of the PowerSync core extension. Running the PowerSync .NET SDK without the core extension or with an outdated version of the core extension is **not supported**.
+
 It is your responsibility to build and bundle extensions you want to use with your app so that they can be loaded.
 
 ## Rust and Tauri


### PR DESCRIPTION
Updates the `Using SQLite Extensions` page to include more detail on loading custom SQLite extensions with the .NET SDK.

Closes #459