### PR TITLE
Remove outdated 'Transaction processing' bullet point from Performance & Limits page

### DIFF
--- a/resources/performance-and-limits.mdx
+++ b/resources/performance-and-limits.mdx
@@ -25,7 +25,6 @@ The PowerSync Cloud **Team** and **Enterprise** plans allow several of these lim
 
 - **Small rows**: 2,000-4,000 operations per second
 - **Large rows**: Up to 5MB per second
-- **Transaction processing**: ~60 transactions per second for smaller transactions
 - **Reprocessing**: Same rates apply when reprocessing Sync Streams/Sync Rules or adding new tables
 
 ### Sync (PowerSync Service → Client)


### PR DESCRIPTION
From @rkistner: that bullet point is outdated and should be removed. Since https://github.com/powersync-ja/powersync-service/pull/228, transactions from Postgres are much less relevant for replication throughput. Not completely irrelevant, but the effect is small enough that it doesn't need to be mentioned anymore. Transactions have no throughput effect on MongoDB. 